### PR TITLE
GitHub Actions to automatically build and release

### DIFF
--- a/.github/actions/attach/action.yml
+++ b/.github/actions/attach/action.yml
@@ -1,0 +1,40 @@
+name: Attach build artifacts to release
+
+
+inputs:
+  filename:
+    description : 'Filename of the build artifact'
+    required    : true
+  upload_url:
+    description : 'Upload URL of the release'
+    required    : true
+  GITHUB_TOKEN:
+    description : 'Secret GitHub token required for uploading to the release'
+    required    : true
+
+
+runs:
+  using: composite
+  steps:
+  -
+    name : Download artifacts
+    uses : actions/download-artifact@v3
+    with:
+      name : ${{ inputs.filename }}
+      path : ./starlight_patch_100/
+  -
+    name  : Zip artifacts
+    shell : bash
+    run: |
+      cd  ./starlight_patch_100/
+      zip  -rmT9  ${{ inputs.filename }}.zip  ./*
+  -
+    name : Attach to release
+    uses : actions/upload-release-asset@v1
+    env:
+      GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+    with:
+      upload_url         : ${{ inputs.upload_url }}
+      asset_path         : ./starlight_patch_100/${{ inputs.filename }}.zip
+      asset_name         : ${{ inputs.filename }}.zip
+      asset_content_type : application/zip

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,61 @@
+name: Build artifacts
+
+
+inputs:
+  tag:
+    description : 'version tag'
+    required    : false
+    default     : ''
+
+
+outputs:
+  filename:
+    description : 'Filename for the build artifacts'
+    value       : ${{ steps.env.outputs.filename }}
+
+
+runs:
+  using: composite
+  steps:
+  -
+    name  : Environment
+    id    : env
+    shell : bash
+    run: |
+      VERS=${{ inputs.tag }}
+      echo "::set-output name=version::${VERS:1}"
+      echo "::set-output name=filename::SMO_Online${{ (inputs.tag != '' && format('_{0}', inputs.tag)) || '' }}"
+  -
+    name : Set up Docker Buildx
+    uses : docker/setup-buildx-action@v2
+  -
+    name : Build environment
+    uses : docker/build-push-action@v3
+    with:
+      pull       : true
+      push       : false
+      load       : true
+      context    : .
+      file       : ./Dockerfile
+      tags       : smoo-build-env
+      platforms  : linux/amd64
+      cache-from : type=gha,scope=smoo-build-env
+      cache-to   : type=gha,scope=smoo-build-env,mode=max
+  -
+    name  : Build mod
+    shell : bash
+    run: |
+      docker  run  --rm     \
+        -u `id -u`:`id -g`  \
+        -v "/$PWD/":/app/   \
+        ${{ (steps.env.outputs.version != '' && format('-e BUILDVER={0}', steps.env.outputs.version)) || '' }}  \
+        smoo-build-env      \
+      ;
+      cp  -r  ./romfs/  ./starlight_patch_100/atmosphere/contents/0100000000010000/.
+  -
+    name : Upload artifacts
+    uses : actions/upload-artifact@v3
+    with:
+      name              : ${{ steps.env.outputs.filename }}
+      path              : ./starlight_patch_100/
+      if-no-files-found : error

--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -1,0 +1,36 @@
+name: Create release
+
+
+inputs:
+  tag:
+    description : 'Version tag'
+    required    : true
+  GITHUB_TOKEN:
+    description : 'Secret GitHub token required to create the release'
+    required    : true
+
+
+outputs:
+  id:
+    value: ${{ steps.release.outputs.id }}
+  html_url:
+    value: ${{ steps.release.outputs.html_url }}
+  upload_url:
+    value: ${{ steps.release.outputs.upload_url }}
+
+
+runs:
+  using: composite
+  steps:
+  -
+    name : Create release
+    id   : release
+    uses : actions/create-release@v1
+    env:
+      GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+    with:
+      tag_name     : ${{ inputs.tag }}
+      release_name : Release ${{ inputs.tag }}
+      body         : ''
+      draft        : true
+      prerelease   : false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build
+
+
+on:
+  push:
+    branches:
+    - '**'
+    tags:
+    - '**'
+    - '!v[0-9]+.[0-9]+.[0-9]+'
+  pull_request:
+    branches:
+    - '**'
+
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    -
+      name : Checkout
+      uses : actions/checkout@v3
+    -
+      name : Build artifacts
+      uses : ./.github/actions/build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+
+on:
+  push:
+    tags:
+    - 'v[0-9]+.[0-9]+.[0-9]+'
+
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      filename: ${{ steps.build.outputs.filename }}
+    steps:
+    -
+      name : Checkout
+      uses : actions/checkout@v3
+    -
+      name : Build artifacts
+      id   : build
+      uses : ./.github/actions/build
+      with:
+        tag : ${{ github.ref_name }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    -
+      name : Checkout
+      uses : actions/checkout@v3
+    -
+      name : Create release
+      id   : release
+      uses : ./.github/actions/release
+      with:
+        tag          : ${{ github.ref_name }}
+        GITHUB_TOKEN : ${{ secrets.GITHUB_TOKEN }}
+    -
+      name : Attach build artifacts to release
+      uses : ./.github/actions/attach
+      with:
+        filename     : ${{ needs.build.outputs.filename }}
+        upload_url   : ${{ steps.release.outputs.upload_url }}
+        GITHUB_TOKEN : ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM  ubuntu:20.04  as  builder
+
+# install dependencies
+RUN   apt-get  update       \
+  &&  apt-get  install  -y  \
+    curl                    \
+    apt-transport-https     \
+    python3                 \
+    python3-pip             \
+  &&  pip  install  keystone-engine  \
+;
+
+# install devkitpro
+RUN   ln  -s  /proc/self/mounts  /etc/mtab  \
+  &&  mkdir  /devkitpro/  \
+  &&  echo "deb [signed-by=/devkitpro/pub.gpg] https://apt.devkitpro.org stable main" >/etc/apt/sources.list.d/devkitpro.list  \
+  &&  curl --fail  -o /devkitpro/pub.gpg  https://apt.devkitpro.org/devkitpro-pub.gpg  \
+  &&  apt-get update  \
+  &&  DEBIAN_FRONTEND=noninteractive  apt-get  install  -y  devkitpro-pacman  \
+  &&  dkp-pacman  --noconfirm  -S switch-dev  \
+;
+
+WORKDIR  /app/
+
+ENV  DEVKITPRO  /opt/devkitpro
+ENTRYPOINT  make

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+export DOCKER_BUILDKIT=1
+docker  build  .  -t smoo-client-build
+docker  run  --rm       \
+  -u $(id -u):$(id -g)  \
+  -v "/$PWD/":/app/     \
+  smoo-client-build     \
+;
+docker  rmi  smoo-client-build
+
+cp  -r  ./romfs/  ./starlight_patch_*/atmosphere/contents/0100000000010000/.


### PR DESCRIPTION
With this workflow, all branches, tags and pull requests will automatically trigger a build action.

The build artifacts (zip file with the build mod) of successfull builds can then be downloaded by logged in GitHub users. (The artifacts can be found on the summary page of run actions.)

Pushing a version tag with the format `v[0-9]+.[0-9]+.[0-9]+` will additionally create a draft release that already has the build artifacts attached. Draft releases are non-public releases that have to be manually published (they are missing a description of what has changed). We could also publish them automatically if that's preffered. Alternatively we could build and attach the artifacts automatically to manually created releases. Or we could remove the release workflow completely, if that functionality isn't wanted at all.

GitHub actions might need to be enabled in the project settings. Afaik (I'm not sure) it's enabled by default for public repositories and disabled for private repositories. Making a private repository public likely leaves the actions disabled.

Examples:
- [a push to a branch](https://github.com/Istador/SuperMarioOdysseyOnline/actions/runs/2659956817)
- [a pushed version tag](https://github.com/Istador/SuperMarioOdysseyOnline/actions/runs/2659959147) created the draft for this [release](https://github.com/Istador/SuperMarioOdysseyOnline/releases/tag/v1.0.1)
- [pull request not breaking the build](https://github.com/Istador/SuperMarioOdysseyOnline/pull/1) (`All checks have passed`)
- [pull request breaking the build](https://github.com/Istador/SuperMarioOdysseyOnline/pull/2) (`All checks have failed`)