### PR TITLE
Disable blocking on Recv calls

### DIFF
--- a/source/server/Client.cpp
+++ b/source/server/Client.cpp
@@ -245,30 +245,34 @@ bool Client::startConnection() {
 
         Logger::log("Sucessful Connection. Waiting to recieve init packet.\n");
 
+        bool waitingForInitPacket = true;
         // wait for client init packet
-        while (true) {
+        while (waitingForInitPacket) {
             if (mSocket->RECV()) {
-                Packet* curPacket = mSocket->mPacketQueue.popFront();
+                if(!mSocket->mPacketQueue.isEmpty()){
 
-                if (curPacket->mType == PacketType::CLIENTINIT) {
-                    InitPacket* initPacket = (InitPacket*)curPacket;
+                    Packet* curPacket = mSocket->mPacketQueue.popFront();
 
-                    Logger::log("Server Max Player Size: %d\n", initPacket->maxPlayers);
+                    if (curPacket->mType == PacketType::CLIENTINIT) {
+                        InitPacket* initPacket = (InitPacket*)curPacket;
 
-                    maxPuppets = initPacket->maxPlayers - 1;
-                } else {
-                    Logger::log("First Packet was not Init!\n");
-                    mIsConnectionActive = false;
+                        Logger::log("Server Max Player Size: %d\n", initPacket->maxPlayers);
+
+                        maxPuppets = initPacket->maxPlayers - 1;
+                    } else {
+                        Logger::log("First Packet was not Init!\n");
+                        mIsConnectionActive = false;
+                    }
+
+                    free(curPacket);
+                    waitingForInitPacket = false;
                 }
-
-                free(curPacket);
 
             } else {
                 Logger::log("Recieve failed! Stopping Connection.\n");
                 mIsConnectionActive = false;
+                waitingForInitPacket = false;
             }
-
-            break;
         }
     }
 

--- a/source/server/SocketBase.cpp
+++ b/source/server/SocketBase.cpp
@@ -7,7 +7,7 @@ SocketBase::SocketBase(const char *name)
 {
     strcpy(this->sockName, name);
 
-    this->sock_flags = 0;
+    this->sock_flags = 0x80;
 }
 
 const char *SocketBase::getStateChar() {

--- a/source/server/SocketClient.cpp
+++ b/source/server/SocketClient.cpp
@@ -82,7 +82,7 @@ bool SocketClient::SEND(Packet *packet) {
     if (packet->mType != PLAYERINF && packet->mType != HACKCAPINF)
         Logger::log("Sending packet: %s\n", packetNames[packet->mType]);
 
-    if ((valread = nn::socket::Send(this->socket_log_socket, buffer, packet->mPacketSize + sizeof(Packet), this->sock_flags) > 0)) {
+    if ((valread = nn::socket::Send(this->socket_log_socket, buffer, packet->mPacketSize + sizeof(Packet), 0) > 0)) {
         return true;
     } else {
         Logger::log("Failed to Fully Send Packet! Result: %d Type: %s Packet Size: %d\n", valread, packetNames[packet->mType], packet->mPacketSize);
@@ -115,9 +115,13 @@ bool SocketClient::RECV() {
         if(result > 0) {
             valread += result;
         } else {
-            Logger::log("Header Read Failed! Value: %d Total Read: %d\n", result, valread);
-            this->closeSocket();
-            return false;
+            if(this->socket_errno==11){
+                return true;
+            } else {
+                Logger::log("Header Read Failed! Value: %d Total Read: %d\n", result, valread);
+                this->closeSocket();
+                return false;
+            }
         }
     }
 


### PR DESCRIPTION
Currently, the way both Yuzu and Ryujinx handle socket communication means that blocking calls to socket commands, such as Recv, halt the entire game thread instead of only the socket 'thread', as is the case on Switch.
This means that, on Switch, blocking calls to Recv can be used to wait until any new data is received from the server before processing it, all while the game is running simultaneously in the background. On emulator, however, these same calls cause the entire game to freeze and stall, as the game only runs whenever new packets are received, and is blocked at all other times.

This PR changes the mod to instead use non-blocking calls to the Recv function. This allows emulators to continue the game instead of just waiting for new packets. As of writing this PR, I have added non-blocking Recv support to Yuzu, and this PR fixes all stuttering, freezing, and black screen issues. Ryujinx currently ignores the changes, but this may change. Where a system/emulator doesn't support the correct flag, this change doesn't affect compatibility.