### PR TITLE
Overhaul gamemode management

### DIFF
--- a/MakefileNSO
+++ b/MakefileNSO
@@ -32,7 +32,7 @@ include $(DEVKITPRO)/libnx/switch_rules
 #---------------------------------------------------------------------------------
 TARGET		?=	$(notdir $(CURDIR))$(SMOVER)
 BUILD		?=	build$(SMOVER)
-SOURCES		:=  source/sead/time source/sead source/puppets source/server source/layouts source/states source/cameras source/nx source
+SOURCES		:=  source/sead/time source/sead source/puppets source/server/hns source/server/gamemode source/server source/layouts source/states source/cameras source/nx source
 DATA		:=	data
 INCLUDES	:=	include include/sead
 
@@ -46,7 +46,7 @@ CFLAGS	:=	-g -Wall -ffunction-sections \
 
 CFLAGS	+=	$(INCLUDE) -D__SWITCH__ -DSMOVER=$(SMOVER) -O3 -DNNSDK -DSWITCH -DBUILDVERSTR=$(BUILDVERSTR) -DBUILDVER=$(BUILDVER) -DDEBUGLOG=$(DEBUGLOG) -DSERVERIP=$(SERVERIP) -DEMU=$(EMU)
 
-CXXFLAGS	:= $(CFLAGS) -fno-rtti -fomit-frame-pointer -fno-exceptions -fno-asynchronous-unwind-tables -fno-unwind-tables -std=gnu++20
+CXXFLAGS	:= $(CFLAGS) -Wno-invalid-offsetof -Wno-volatile -fno-rtti -fomit-frame-pointer -fno-exceptions -fno-asynchronous-unwind-tables -fno-unwind-tables -std=gnu++20
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS  =  -specs=../switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map) -Wl,--version-script=$(TOPDIR)/exported.txt -Wl,-init=__custom_init -Wl,-fini=__custom_fini -nostdlib

--- a/include/al/util.hpp
+++ b/include/al/util.hpp
@@ -72,6 +72,9 @@ namespace al
     PlayerActorBase *tryGetPlayerActor(al::PlayerHolder const *, int);
 
     sead::Heap *getCurrentHeap(void);
+    sead::Heap* getStationedHeap();
+    sead::Heap* getSequenceHeap();
+    sead::Heap* getSceneHeap();
 
     al::Projection *getProjection(al::IUseCamera const *, int);
 

--- a/include/game/StageScene/StageSceneStateServerConfig.hpp
+++ b/include/game/StageScene/StageSceneStateServerConfig.hpp
@@ -17,6 +17,7 @@
 
 #include "logger.hpp"
 #include "server/gamemode/GameModeConfigMenu.hpp"
+#include "server/gamemode/GameModeConfigMenuFactory.hpp"
 
 class FooterParts;
 
@@ -65,14 +66,18 @@ class StageSceneStateServerConfig : public al::HostStateBase<al::Scene>, public 
         // Root Page, contains buttons for gamemode config, server reconnecting, and server ip address changing
         SimpleLayoutMenu* mMainOptions = nullptr;
         CommonVerticalList *mMainOptionsList = nullptr;
-        // Sub-Page for Mode configuration, has buttons for selecting current gamemode and configuring currently selected mode (if no mode is chosen, button will not do anything)
-        SimpleLayoutMenu* mGamemodeConfig = nullptr;
-        CommonVerticalList* mGameModeConfigList = nullptr;
         // Sub-Page of Mode config, used to select a gamemode for the client to use
         SimpleLayoutMenu* mModeSelect = nullptr;
         CommonVerticalList* mModeSelectList = nullptr;
-        // Controls what shows up in specific gamemode config page
-        GameModeConfigMenu *mGamemodeConfigMenu = nullptr;
+
+        // Sub-Pages for Mode configuration, has buttons for selecting current gamemode and configuring currently selected mode (if no mode is chosen, button will not do anything)
+        struct GameModeEntry {
+            GameModeConfigMenu* mMenu;
+            SimpleLayoutMenu* mLayout = nullptr;
+            CommonVerticalList* mList = nullptr;
+        };
+        sead::SafeArray<GameModeEntry, GameModeConfigMenuFactory::getMenuCount()> mGamemodeConfigMenus;
+        GameModeEntry *mGamemodeConfigMenu = nullptr;
 
         bool mIsDecideConfig = false;
 };

--- a/include/server/Client.hpp
+++ b/include/server/Client.hpp
@@ -96,8 +96,6 @@ class Client {
         static bool isNeedUpdateShines();
         bool isShineCollected(int shineId);
 
-        static void initMode(GameModeInitInfo const &initInfo);
-
         static void sendHackCapInfPacket(const HackCap *hackCap);
         static void sendPlayerInfPacket(const PlayerActorHakoniwa *player);
         static void sendGameInfPacket(const PlayerActorHakoniwa *player, GameDataHolderAccessor holder);
@@ -109,8 +107,6 @@ class Client {
 
         int getCollectedShinesCount() { return curCollectedShines.size(); }
         int getShineID(int index) { if (index < curCollectedShines.size()) { return curCollectedShines[index]; } return -1; }
-
-        static void setGameActive(bool state);
 
         static void setStageInfo(GameDataHolderAccessor holder);
 
@@ -130,26 +126,7 @@ class Client {
 
         static PuppetActor* getDebugPuppet();
 
-        static GameMode getServerMode() {
-            return sInstance ? sInstance->mServerMode : GameMode::NONE;
-        }
-
-        static void setServerMode(GameMode mode) {
-            if (sInstance) sInstance->mServerMode = mode;
-        }
-
-        static GameMode getCurrentMode();
-
-        static GameModeBase* getModeBase() { return sInstance ? sInstance->mCurMode : nullptr; }
-
-        template <typename T>
-        static T* getMode() {return sInstance ? (T*)sInstance->mCurMode : nullptr;}
-
-        static GameModeConfigMenu* tryCreateModeMenu();
-
         static int getMaxPlayerCount() { return sInstance ? sInstance->maxPuppets + 1 : 10;}
-
-        static void toggleCurrentMode();
 
         static void updateStates();
 
@@ -173,6 +150,12 @@ class Client {
             return 0;
         }
 
+        static PuppetHolder* getPuppetHolder() {
+            if (sInstance)
+                return sInstance->mPuppetHolder;
+            return nullptr;
+        }
+
         static void setSceneInfo(const al::ActorInitInfo& initInfo, const StageScene *stageScene);
 
         static bool tryRegisterShine(Shine* shine);
@@ -183,23 +166,6 @@ class Client {
 
         static bool openKeyboardIP();
         static bool openKeyboardPort();
-
-        static GameModeInfoBase* getModeInfo() {
-            return sInstance ? sInstance->mModeInfo : nullptr;
-        }
-
-        // should only be called during mode init
-        static void setModeInfo(GameModeInfoBase* info) {
-            if(sInstance) sInstance->mModeInfo = info;
-        }
-
-        static void tryRestartCurrentMode();
-
-        static bool isModeActive() { return sInstance ? sInstance->mIsModeActive : false; }
-
-        static bool isSelectedMode(GameMode mode) {
-            return sInstance ? sInstance->mCurMode->getMode() == mode : false;
-        }
 
         static void showConnect();
 
@@ -295,21 +261,11 @@ class Client {
 
         sead::FrameHeap *mHeap = nullptr; // Custom FrameHeap used for all Client related memory
 
-        // --- Mode Info ---
-
-        GameModeBase* mCurMode = nullptr;
-
-        GameMode mServerMode = GameMode::NONE; // current mode set by server, will sometimes not match up with current game mode (until scene re-init) if server switches gamemodes
-
-        GameModeInfoBase *mModeInfo = nullptr;
-
-        bool mIsModeActive = false;
-
         // --- Puppet Info ---
 
         int maxPuppets = 9;  // default max player count is 10, so default max puppets will be 9
         
-        PuppetInfo *mPuppetInfoArr[MAXPUPINDEX];
+        PuppetInfo *mPuppetInfoArr[MAXPUPINDEX] = {};
 
         PuppetHolder *mPuppetHolder = nullptr;
 

--- a/include/server/gamemode/GameModeBase.hpp
+++ b/include/server/gamemode/GameModeBase.hpp
@@ -21,7 +21,6 @@ enum GameMode : s8 {
 
 // struct containing info about the games state for use in gamemodes
 struct GameModeInitInfo {
-
     GameModeInitInfo(al::ActorInitInfo* info, al::Scene *scene){
         mLayoutInitInfo = info->mLayoutInitInfo;
         mPlayerHolder = info->mActorSceneInfo.mPlayerHolder;
@@ -47,6 +46,7 @@ struct GameModeInitInfo {
 class GameModeBase : public al::IUseName, public al::IUseSceneObjHolder {
 public:
     GameModeBase(const char* name) { mName = name; }
+    virtual ~GameModeBase() = default;
     const char* getName() const override { return mName.cstr(); }
     al::SceneObjHolder* getSceneObjHolder() const override { return mSceneObjHolder; }
 
@@ -56,7 +56,7 @@ public:
 
     virtual void init(GameModeInitInfo const &info);
 
-    virtual void begin() { mIsActive = true;}
+    virtual void begin() { mIsActive = true; }
     virtual void update();
     virtual void end() { mIsActive = false; }
     

--- a/include/server/gamemode/GameModeConfigMenuFactory.hpp
+++ b/include/server/gamemode/GameModeConfigMenuFactory.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "al/factory/Factory.h"
+#include "server/hns/HideAndSeekConfigMenu.hpp"
+#include "server/gamemode/GameModeConfigMenu.hpp"
+
+typedef GameModeConfigMenu* (*createMenu)(const char* name);
+
+template <class T>
+GameModeConfigMenu* createGameModeConfigMenu(const char* name) {
+    return new T();
+};
+
+__attribute((used)) constexpr al::NameToCreator<createMenu> menuTable[] = {
+    {"HideAndSeek", &createGameModeConfigMenu<HideAndSeekConfigMenu>},
+};
+
+class GameModeConfigMenuFactory : public al::Factory<createMenu> {
+public:
+    GameModeConfigMenuFactory(const char* fName) {
+        this->factoryName = fName;
+        this->actorTable = menuTable;
+        this->factoryCount = sizeof(menuTable) / sizeof(menuTable[0]);
+    };
+
+    constexpr static const char* getMenuName(int idx);
+    constexpr static int getMenuCount();
+};
+
+constexpr const char* GameModeConfigMenuFactory::getMenuName(int idx) {
+    if (idx >= 0 && idx < sizeof(menuTable) / sizeof(menuTable[0]))
+        return menuTable[idx].creatorName;
+    return nullptr;
+}
+
+constexpr int GameModeConfigMenuFactory::getMenuCount() {
+    return sizeof(menuTable) / sizeof(menuTable[0]);
+}

--- a/include/server/gamemode/GameModeFactory.hpp
+++ b/include/server/gamemode/GameModeFactory.hpp
@@ -1,9 +1,8 @@
 #pragma once
 
 #include "al/factory/Factory.h"
-#include "layouts/HideAndSeekIcon.h"
 #include "server/gamemode/GameModeBase.hpp"
-#include "server/HideAndSeekMode.hpp"
+#include "server/hns/HideAndSeekMode.hpp"
 
 typedef GameModeBase* (*createMode)(const char* name);
 
@@ -37,19 +36,19 @@ class GameModeFactory : public al::Factory<createMode> {
 
 // TODO: possibly use shadows' crc32 hash algorithm for this
 constexpr const char* GameModeFactory::getModeString(GameMode mode) {
-    if(mode >= 0 && mode < sizeof(modeTable)/sizeof(modeTable[0]))
+    if(mode >= 0 && (size_t)mode < sizeof(modeTable)/sizeof(modeTable[0]))
         return modeTable[mode].creatorName;
     return nullptr;
 }
 
 constexpr const char* GameModeFactory::getModeName(GameMode mode) {
-    if(mode >= 0 && mode < sizeof(modeNames)/sizeof(modeNames[0]))
+    if(mode >= 0 && (size_t)mode < sizeof(modeNames)/sizeof(modeNames[0]))
         return modeNames[mode];
     return nullptr;
 }
 
 constexpr const char* GameModeFactory::getModeName(int idx) {
-    if(idx >= 0 && idx < sizeof(modeNames)/sizeof(modeNames[0]))
+    if(idx >= 0 && (size_t)idx < sizeof(modeNames)/sizeof(modeNames[0]))
         return modeNames[idx];
     return nullptr;
 }

--- a/include/server/gamemode/GameModeInfoBase.hpp
+++ b/include/server/gamemode/GameModeInfoBase.hpp
@@ -1,21 +1,11 @@
 #pragma once
 
 #include "server/gamemode/GameModeBase.hpp"
+#include <heap/seadHeap.h>
 
 // base struct containing info about the current gamemode
 struct GameModeInfoBase {
     GameMode mMode;
 };
 
-template<class T>
-T *createModeInfo() {
-    // using sequence heap to create mode info should allow for mode info to persist between scenes
-    sead::Heap* seqHeap = sead::HeapMgr::instance()->findHeapByName("SequenceHeap", 0);
-
-    if (seqHeap) {
-        return new (seqHeap) T();
-    } else {
-        // if failed to get sequence heap, fall back to current heap (will return null if current heap is also null)
-        return new T();
-    }
-}
+#include "server/gamemode/GameModeManager.hpp"

--- a/include/server/gamemode/GameModeManager.hpp
+++ b/include/server/gamemode/GameModeManager.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <heap/seadDisposer.h>
+#include <heap/seadHeap.h>
+#include <container/seadSafeArray.h>
+#include "server/gamemode/GameModeBase.hpp"
+#include "server/gamemode/GameModeInfoBase.hpp"
+
+class GameModeManager {
+    SEAD_SINGLETON_DISPOSER(GameModeManager)
+    GameModeManager();
+    ~GameModeManager();
+
+public:
+    void setMode(GameMode mode);
+    void initScene(const GameModeInitInfo& info);
+    void begin();
+    void end();
+    void update();
+
+    GameMode getGameMode() const { return mCurMode; }
+    template<class T> T* getMode() const { return static_cast<T*>(mCurModeBase); }
+    template<class T> T* getInfo() const { return static_cast<T*>(mModeInfo); }
+    void setInfo(GameModeInfoBase* info) {
+        mModeInfo = info;
+    }
+
+    template<class T>
+    T* createModeInfo();
+
+    sead::Heap* getHeap() { return mHeap; }
+    void toggleActive();
+    void setActive(bool active) { mActive = active; }
+    void setPaused(bool paused);
+    bool isMode(GameMode mode) const { return mCurMode == mode; }
+    bool isActive() const { return mActive; }
+    bool isModeAndActive(GameMode mode) const { return isMode(mode) && isActive(); }
+    bool isPaused() const { return mPaused; }
+private:
+    sead::Heap* mHeap = nullptr;
+
+    bool mActive = false;
+    bool mPaused = false;
+    bool mWasSceneTrans = false;
+    bool mWasSetMode = false;
+    GameMode mCurMode = GameMode::NONE;
+    GameModeBase* mCurModeBase = nullptr;
+    GameModeInfoBase *mModeInfo = nullptr;
+    GameModeInitInfo *mLastInitInfo = nullptr;
+};
+
+template<class T>
+T* GameModeManager::createModeInfo() {
+    sead::ScopedCurrentHeapSetter heapSetter(mHeap);
+
+    T* info = new T();
+    mModeInfo = info;
+    return info;
+}

--- a/include/server/hns/HideAndSeekConfigMenu.hpp
+++ b/include/server/hns/HideAndSeekConfigMenu.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "gamemode/GameModeConfigMenu.hpp"
+#include "server/gamemode/GameModeConfigMenu.hpp"
 #include "game/Layouts/CommonVerticalList.h"
 #include "server/gamemode/GameModeBase.hpp"
 

--- a/include/server/hns/HideAndSeekMode.hpp
+++ b/include/server/hns/HideAndSeekMode.hpp
@@ -2,11 +2,11 @@
 
 #include <math.h>
 #include "al/camera/CameraTicket.h"
-#include "gamemode/GameModeBase.hpp"
-#include "gamemode/GameModeInfoBase.hpp"
+#include "server/gamemode/GameModeBase.hpp"
+#include "server/gamemode/GameModeInfoBase.hpp"
 #include "server/gamemode/GameModeConfigMenu.hpp"
 #include "server/gamemode/GameModeTimer.hpp"
-#include "server/HideAndSeekConfigMenu.hpp"
+#include "server/hns/HideAndSeekConfigMenu.hpp"
 
 struct HideAndSeekInfo : GameModeInfoBase {
     HideAndSeekInfo() { mMode = GameMode::HIDEANDSEEK; }

--- a/source/hooks.cpp
+++ b/source/hooks.cpp
@@ -26,10 +26,10 @@
 #include "math/seadVector.h"
 #include "rs/util/InputUtil.h"
 #include "sead/prim/seadSafeString.h"
-#include "server/HideAndSeekMode.hpp"
+#include "server/hns/HideAndSeekMode.hpp"
 
 bool comboBtnHook(int port) {
-    if (Client::isModeActive()) { // only switch to combo if any gamemode is active
+    if (GameModeManager::instance()->isActive()) { // only switch to combo if any gamemode is active
         return !al::isPadHoldL(port) && al::isPadTriggerDown(port);
     } else {
         return al::isPadTriggerDown(port);
@@ -110,19 +110,19 @@ void initNerveStateHook(StageSceneStatePauseMenu* stateParent, StageSceneStateOp
 
 // skips starting both coin counters
 void startCounterHook(CoinCounter* thisPtr) {
-    if (!Client::isModeActive()) {
+    if (!GameModeManager::instance()->isActive()) {
         thisPtr->tryStart();
     }
 }
 
 // Simple hook that can be used to override isModeE3 checks to enable/disable certain behaviors
 bool modeE3Hook() {
-    return Client::isModeActive();
+    return GameModeManager::instance()->isActive();
 }
 
 // Skips ending the play guide layout if a mode is active, since the mode would have already ended it
 void playGuideEndHook(al::SimpleLayoutAppearWaitEnd* thisPtr) {
-    if (!Client::isModeActive()) {
+    if (!GameModeManager::instance()->isActive()) {
         thisPtr->end();
     }
 }
@@ -135,14 +135,14 @@ void initHackCapHook(al::LiveActor *cappy) {
 
 al::PlayerHolder* createTicketHook(StageScene* curScene) {
     // only creates custom gravity camera ticket if hide and seek mode is active
-    if (Client::isSelectedMode(GameMode::HIDEANDSEEK)) {
+    if (GameModeManager::instance()->isMode(GameMode::HIDEANDSEEK)) {
         al::CameraDirector* director = curScene->getCameraDirector();
         if (director) {
             if (director->mFactory) {
                 al::CameraTicket* gravityCamera = director->createCameraFromFactory(
                     "CameraPoserCustom", nullptr, 0, 5, sead::Matrix34f::ident);
 
-                HideAndSeekMode* mode = Client::getMode<HideAndSeekMode>();
+                HideAndSeekMode* mode = GameModeManager::instance()->getMode<HideAndSeekMode>();
 
                 mode->setCameraTicket(gravityCamera);
             }
@@ -157,9 +157,9 @@ bool borderPullBackHook(WorldEndBorderKeeper* thisPtr) {
     bool isFirstStep = al::isFirstStep(thisPtr);
 
     if (isFirstStep) {
-        if (Client::isSelectedMode(GameMode::HIDEANDSEEK) && Client::isModeActive()) {
+        if (GameModeManager::instance()->isModeAndActive(GameMode::HIDEANDSEEK)) {
 
-            HideAndSeekMode* mode = Client::getMode<HideAndSeekMode>();
+            HideAndSeekMode* mode = GameModeManager::instance()->getMode<HideAndSeekMode>();
 
             if (mode->isUseGravity()) {
                 killMainPlayer(thisPtr->mActor);

--- a/source/layouts/HideAndSeekIcon.cpp
+++ b/source/layouts/HideAndSeekIcon.cpp
@@ -5,7 +5,7 @@
 #include "al/string/StringTmp.h"
 #include "prim/seadSafeString.h"
 #include "server/gamemode/GameModeTimer.hpp"
-#include "server/HideAndSeekMode.hpp"
+#include "server/hns/HideAndSeekMode.hpp"
 #include "server/Client.hpp"
 #include "al/util.hpp"
 #include "logger.hpp"
@@ -16,7 +16,7 @@ HideAndSeekIcon::HideAndSeekIcon(const char* name, const al::LayoutInitInfo& ini
 
     al::initLayoutActor(this, initInfo, "HideAndSeekIcon", 0);
 
-    mInfo = (HideAndSeekInfo*)Client::getModeInfo();
+    mInfo = GameModeManager::instance()->getInfo<HideAndSeekInfo>();
 
     initNerve(&nrvHideAndSeekIconEnd, 0);
 

--- a/source/puppets/PuppetActor.cpp
+++ b/source/puppets/PuppetActor.cpp
@@ -14,8 +14,9 @@
 #include "actors/PuppetActor.h"
 #include "math/seadQuat.h"
 #include "math/seadVector.h"
+#include "server/gamemode/GameModeManager.hpp"
 #include "server/gamemode/GameModeBase.hpp"
-#include "server/HideAndSeekMode.hpp"
+#include "server/hns/HideAndSeekMode.hpp"
 
 static const char *subActorNames[] = {
     "顔", // Face
@@ -189,9 +190,9 @@ void PuppetActor::control() {
         }
 
         if (mNameTag) {
-            if (Client::isSelectedMode(GameMode::HIDEANDSEEK) && Client::isModeActive()) {
+            if (GameModeManager::instance()->isModeAndActive(GameMode::HIDEANDSEEK)) {
                 mNameTag->mIsAlive =
-                    Client::getMode<HideAndSeekMode>()->isPlayerIt() && mInfo->isIt;
+                    GameModeManager::instance()->getMode<HideAndSeekMode>()->isPlayerIt() && mInfo->isIt;
                 
             } else {
                 if(!mNameTag->mIsAlive)

--- a/source/server/gamemode/GameModeManager.cpp
+++ b/source/server/gamemode/GameModeManager.cpp
@@ -1,0 +1,92 @@
+#include "server/gamemode/GameModeManager.hpp"
+#include <cstring>
+#include <heap/seadFrameHeap.h>
+#include "al/util.hpp"
+#include "basis/seadNew.h"
+#include "heap/seadHeapMgr.h"
+#include "server/gamemode/GameModeBase.hpp"
+#include "server/gamemode/GameModeFactory.hpp"
+
+SEAD_SINGLETON_DISPOSER_IMPL(GameModeManager)
+
+GameModeManager::GameModeManager() {
+    mHeap = sead::FrameHeap::create(0x100000, "GameModeHeap", al::getSequenceHeap(), 8,
+                                    sead::Heap::HeapDirection::cHeapDirection_Reverse, false);
+    setMode(GameMode::HIDEANDSEEK);
+}
+
+void GameModeManager::begin() {
+    if (mCurModeBase) {
+        sead::ScopedCurrentHeapSetter heapSetter(mHeap);
+        mCurModeBase->begin();
+    }
+}
+
+void GameModeManager::end() {
+    if (mCurModeBase) {
+        sead::ScopedCurrentHeapSetter heapSetter(mHeap);
+        mCurModeBase->end();
+    }
+}
+
+void GameModeManager::toggleActive() {
+    mActive = !mActive;
+}
+
+void GameModeManager::setPaused(bool paused) {
+    mPaused = paused;
+}
+
+void GameModeManager::setMode(GameMode mode) {
+    mCurMode = mode;
+
+    mWasSetMode = true; // recreate in initScene
+}
+
+void GameModeManager::update() {
+    if (!mCurModeBase) return;
+    bool inScene = al::getSceneHeap() != nullptr;
+    if ((mActive && inScene && !mPaused && !mCurModeBase->isModeActive()) || mWasSceneTrans) begin();
+    if ((!mActive || mPaused || !inScene) && mCurModeBase->isModeActive()) end();
+    mWasSceneTrans = false;
+    if (mCurModeBase && mCurModeBase->isModeActive()) {
+        sead::ScopedCurrentHeapSetter heapSetter(mHeap);
+        mCurModeBase->update();
+    }
+}
+
+void GameModeManager::initScene(const GameModeInitInfo& info) {
+    sead::ScopedCurrentHeapSetter heapSetter(mHeap);
+
+    if (mCurModeBase != nullptr) {
+        delete mCurModeBase;
+    }
+
+    if (mLastInitInfo != nullptr) {
+        delete mLastInitInfo;
+    }
+
+    if (mCurMode == GameMode::NONE) {
+        mCurModeBase = nullptr;
+        mModeInfo = nullptr;
+        return;
+    }
+
+    mLastInitInfo = new GameModeInitInfo(info);
+
+    if (!mCurModeBase && mWasSetMode) {
+        GameModeFactory factory("GameModeFactory");
+        const char* name = factory.getModeString(mCurMode);
+        mCurModeBase = factory.getCreator(name)(name);
+        if (mLastInitInfo) {  // check if there's a previously used init info
+            mCurModeBase->init(*mLastInitInfo);
+        }
+        mWasSetMode = false;
+    }
+
+    if (mCurModeBase) {
+        mCurModeBase->init(*mLastInitInfo);
+        if (mCurModeBase->isModeActive())
+            mWasSceneTrans = true;
+    }
+}

--- a/source/server/gamemode/GameModeManager.cpp
+++ b/source/server/gamemode/GameModeManager.cpp
@@ -58,8 +58,9 @@ void GameModeManager::update() {
 void GameModeManager::initScene(const GameModeInitInfo& info) {
     sead::ScopedCurrentHeapSetter heapSetter(mHeap);
 
-    if (mCurModeBase != nullptr) {
+    if (mCurModeBase != nullptr && mWasSetMode) {
         delete mCurModeBase;
+        mCurModeBase = nullptr;
     }
 
     if (mLastInitInfo != nullptr) {
@@ -68,19 +69,17 @@ void GameModeManager::initScene(const GameModeInitInfo& info) {
 
     if (mCurMode == GameMode::NONE) {
         mCurModeBase = nullptr;
+        delete mModeInfo;
         mModeInfo = nullptr;
         return;
     }
 
     mLastInitInfo = new GameModeInitInfo(info);
 
-    if (!mCurModeBase && mWasSetMode) {
+    if (mWasSetMode) {
         GameModeFactory factory("GameModeFactory");
         const char* name = factory.getModeString(mCurMode);
         mCurModeBase = factory.getCreator(name)(name);
-        if (mLastInitInfo) {  // check if there's a previously used init info
-            mCurModeBase->init(*mLastInitInfo);
-        }
         mWasSetMode = false;
     }
 

--- a/source/server/hns/GameModeTimer.cpp
+++ b/source/server/hns/GameModeTimer.cpp
@@ -2,6 +2,7 @@
 #include <math.h>
 #include "al/util/ControllerUtil.h"
 #include "server/DeltaTime.hpp"
+#include "logger.hpp"
 
 GameModeTimer::GameModeTimer(bool isCountUp, float milli, int seconds, int minutes, int hours) {
     mIsCountUp = isCountUp;
@@ -24,10 +25,14 @@ GameModeTimer::GameModeTimer() {
 }
 
 void GameModeTimer::setTime(float milli, int seconds, int minutes, int hours) {
-    if(milli >= 0) mTime.mMilliseconds = milli;
-    if(seconds >= 0) mTime.mSeconds = seconds;
-    if(minutes >= 0) mTime.mMinutes = minutes;
-    if(hours >= 0) mTime.mHours = hours;
+    if (milli >= 0)
+        mTime.mMilliseconds = milli;
+    if (seconds >= 0)
+        mTime.mSeconds = seconds;
+    if (minutes >= 0)
+        mTime.mMinutes = minutes;
+    if (hours >= 0)
+        mTime.mHours = hours;
 }
 
 void GameModeTimer::setTime(GameTime const& time) {
@@ -35,7 +40,6 @@ void GameModeTimer::setTime(GameTime const& time) {
 }
 
 void GameModeTimer::updateTimer() {
-
     if (mIsUseControl) {
         timerControl();
     }
@@ -43,11 +47,11 @@ void GameModeTimer::updateTimer() {
     if (mIsEnabled) {
         if (mIsCountUp) {
             mTime.mMilliseconds += Time::deltaTime;
-            
-            if(mTime.mMilliseconds >= 1) {
+
+            if (mTime.mMilliseconds >= 1) {
                 mTime.mMilliseconds--;
                 mTime.mSeconds++;
-                if(mTime.mSeconds >= 60) {
+                if (mTime.mSeconds >= 60) {
                     mTime.mSeconds = 0;
                     mTime.mMinutes++;
                     if (mTime.mMinutes >= 60) {
@@ -61,7 +65,7 @@ void GameModeTimer::updateTimer() {
             if (mTime.mMilliseconds >= 1) {
                 mTime.mMilliseconds--;
                 mTime.mSeconds--;
-                if(mTime.mSeconds < 0) {
+                if (mTime.mSeconds < 0) {
                     mTime.mSeconds = 59;
                     mTime.mMinutes--;
                     if (mTime.mMinutes < 0) {
@@ -79,41 +83,44 @@ void GameModeTimer::updateTimer() {
 }
 
 void GameModeTimer::timerControl() {
-
-    if(al::isPadHoldRight(-1)) {
-        mTime.mMilliseconds = 0;
-        mTime.mSeconds++;
-        if(mTime.mSeconds >= 60) {
+    if (al::isPadHoldL(-1)) {
+        if (al::isPadTriggerDown(-1)) {
+            mTime.mMilliseconds = 0;
             mTime.mSeconds = 0;
-            mTime.mMinutes++;
-            if (mTime.mMinutes >= 60) {
-                mTime.mMinutes = 0;
-                mTime.mHours++;
-            }
+            mTime.mMinutes = 0;
+            mTime.mHours = 0;
         }
-    }
-
-    if(al::isPadTriggerLeft(-1)) {
-        mTime.mMilliseconds = 0;
-        mTime.mSeconds--;
-        if(mTime.mSeconds < 0) {
-            mTime.mSeconds = 59;
-            mTime.mMinutes--;
-            if (mTime.mMinutes < 0) {
-                if (mTime.mHours > 0) {
-                    mTime.mMinutes = 59;
-                    mTime.mHours--;
-                } else {
+    } else {
+        if (al::isPadHoldRight(-1)) {
+            mTime.mMilliseconds = 0;
+            mTime.mSeconds++;
+            if (mTime.mSeconds >= 60) {
+                mTime.mSeconds = 0;
+                mTime.mMinutes++;
+                if (mTime.mMinutes >= 60) {
                     mTime.mMinutes = 0;
+                    mTime.mHours++;
                 }
             }
         }
-    }
 
-    if(al::isPadHoldL(-1) && al::isPadTriggerDown(-1)) {
-        mTime.mMilliseconds = 0;
-        mTime.mSeconds = 0;
-        mTime.mMinutes = 0;
-        mTime.mHours = 0;
+        if (al::isPadTriggerLeft(-1)) {
+            mTime.mMilliseconds = 0;
+            if (mTime.mMinutes != 0) {
+                mTime.mSeconds--;
+                if (mTime.mSeconds < 0) {
+                    mTime.mSeconds = 59;
+                    mTime.mMinutes--;
+                    if (mTime.mMinutes < 0) {
+                        if (mTime.mHours > 0) {
+                            mTime.mMinutes = 59;
+                            mTime.mHours--;
+                        } else {
+                            mTime.mMinutes = 0;
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/source/server/hns/HideAndSeekConfigMenu.cpp
+++ b/source/server/hns/HideAndSeekConfigMenu.cpp
@@ -1,7 +1,8 @@
-#include "server/HideAndSeekConfigMenu.hpp"
+#include "server/hns/HideAndSeekConfigMenu.hpp"
 #include <cmath>
 #include "logger.hpp"
-#include "server/HideAndSeekMode.hpp"
+#include "server/gamemode/GameModeManager.hpp"
+#include "server/hns/HideAndSeekMode.hpp"
 #include "server/Client.hpp"
 
 HideAndSeekConfigMenu::HideAndSeekConfigMenu() : GameModeConfigMenu() {}
@@ -22,7 +23,7 @@ const sead::WFixedSafeString<0x200> *HideAndSeekConfigMenu::getStringData() {
 
 bool HideAndSeekConfigMenu::updateMenu(int selectIndex) {
 
-    HideAndSeekInfo *curMode = (HideAndSeekInfo*)Client::getModeInfo();
+    HideAndSeekInfo *curMode = GameModeManager::instance()->getInfo<HideAndSeekInfo>();
 
     Logger::log("Setting Gravity Mode.\n");
 
@@ -33,13 +34,13 @@ bool HideAndSeekConfigMenu::updateMenu(int selectIndex) {
     
     switch (selectIndex) {
         case 0: {
-            if (Client::isSelectedMode(GameMode::HIDEANDSEEK)) {
+            if (GameModeManager::instance()->isMode(GameMode::HIDEANDSEEK)) {
                 curMode->mIsUseGravity = true;
             }
             return true;
         }
         case 1: {
-            if (Client::isSelectedMode(GameMode::HIDEANDSEEK)) {
+            if (GameModeManager::instance()->isMode(GameMode::HIDEANDSEEK)) {
                 curMode->mIsUseGravity = false;
             }
             return true;

--- a/source/states/StageSceneStateServerConfig.cpp
+++ b/source/states/StageSceneStateServerConfig.cpp
@@ -12,8 +12,10 @@
 #include "prim/seadStringUtil.h"
 #include "rs/util/InputUtil.h"
 #include "server/gamemode/GameModeBase.hpp"
+#include "server/gamemode/GameModeConfigMenuFactory.hpp"
 #include "server/gamemode/GameModeFactory.hpp"
-#include "server/HideAndSeekMode.hpp"
+#include "server/gamemode/GameModeManager.hpp"
+#include "server/hns/HideAndSeekMode.hpp"
 
 StageSceneStateServerConfig::StageSceneStateServerConfig(const char *name, al::Scene *scene, const al::LayoutInitInfo &initInfo, FooterParts *footerParts, GameDataHolder *dataHolder, bool) : al::HostStateBase<al::Scene>(name, scene) {
     mFooterParts = footerParts;
@@ -64,18 +66,22 @@ StageSceneStateServerConfig::StageSceneStateServerConfig(const char *name, al::S
     mModeSelectList->addStringData(modeSelectOptions->mBuffer, "TxtContent");
 
     // gamemode config menu
-    mGamemodeConfig = new SimpleLayoutMenu("GameModeConfigMenu", "OptionSelect", initInfo, 0, false);
-    mGameModeConfigList = new CommonVerticalList(mGamemodeConfig, initInfo, true);
+    GameModeConfigMenuFactory factory("GameModeConfigFactory");
+    for (int mode = 0; mode < factory.getMenuCount(); mode++) {
+        GameModeEntry& entry = mGamemodeConfigMenus[mode];
+        const char* name = factory.getMenuName(mode);
+        entry.mMenu = factory.getCreator(name)(name);
+        entry.mLayout = new SimpleLayoutMenu("GameModeConfigMenu", "OptionSelect", initInfo, 0, false);
+        entry.mList = new CommonVerticalList(entry.mLayout, initInfo, true);
 
-    al::setPaneString(mGamemodeConfig, "TxtOption", u"Gamemode Configuration", 0);
+        al::setPaneString(entry.mLayout, "TxtOption", u"Gamemode Configuration", 0);
 
-    mGamemodeConfigMenu = Client::tryCreateModeMenu();
+        entry.mList->initDataNoResetSelected(entry.mMenu->getMenuSize());
 
-    if (mGamemodeConfigMenu) {
-        mGameModeConfigList->initDataNoResetSelected(mGamemodeConfigMenu->getMenuSize());
 
-        mGameModeConfigList->addStringData(mGamemodeConfigMenu->getStringData(), "TxtContent");
+        entry.mList->addStringData(entry.mMenu->getStringData(), "TxtContent");
     }
+
 
     mCurrentList = mMainOptionsList;
     mCurrentMenu = mMainOptions;
@@ -224,15 +230,16 @@ void StageSceneStateServerConfig::exeRestartServer() {
 
 void StageSceneStateServerConfig::exeGamemodeConfig() {
     if (al::isFirstStep(this)) {
-        mCurrentList = mGameModeConfigList;
-        mCurrentMenu = mGamemodeConfig;
+        mGamemodeConfigMenu = &mGamemodeConfigMenus[GameModeManager::instance()->getGameMode()];
+        mCurrentList = mGamemodeConfigMenu->mList;
+        mCurrentMenu = mGamemodeConfigMenu->mLayout;
         subMenuStart();
     }
 
     subMenuUpdate();
 
     if (mIsDecideConfig && mCurrentList->isDecideEnd()) {
-        if (mGamemodeConfigMenu->updateMenu(mCurrentList->mCurSelected)) {
+        if (mGamemodeConfigMenu->mMenu->updateMenu(mCurrentList->mCurSelected)) {
             endSubMenu();
         }
     }
@@ -252,7 +259,7 @@ void StageSceneStateServerConfig::exeGamemodeSelect() {
 
     if (mIsDecideConfig && mCurrentList->isDecideEnd()) {
         Logger::log("Setting Server Mode to: %d\n", mCurrentList->mCurSelected);
-        Client::setServerMode(static_cast<GameMode>(mCurrentList->mCurSelected));
+        GameModeManager::instance()->setMode(static_cast<GameMode>(mCurrentList->mCurSelected));
         endSubMenu();
     }
 }


### PR DESCRIPTION
Allows gamemodes to get switched mid-scene, though layouts are not created on the sequence layout system so it still requires a scene change. This PR was mostly meant to clean up the gamemode system and separate the client from gamemodes going forward.