### PR TITLE
don't send empty GameInf packets and resend them on reconnect

### DIFF
--- a/include/packets/GameInf.h
+++ b/include/packets/GameInf.h
@@ -6,7 +6,7 @@
 struct PACKED GameInf : Packet {
     GameInf() : Packet() {this->mType = PacketType::GAMEINF; mPacketSize = sizeof(GameInf) - sizeof(Packet);};
     bool1 is2D = false;
-    u8 scenarioNo = -1;
+    u8 scenarioNo = 255;
     char stageName[0x40] = {};
 
     bool operator==(const GameInf &rhs) const {

--- a/include/server/Client.hpp
+++ b/include/server/Client.hpp
@@ -181,6 +181,7 @@ class Client {
         SocketClient *mSocket;
 
     private:
+        void initConnection(PlayerConnect *initPacket);
         void updatePlayerInfo(PlayerInf *packet);
         void updateHackCapInfo(HackCapInf *packet);
         void updateGameInfo(GameInf *packet);
@@ -221,6 +222,7 @@ class Client {
         // Backups for our last player/game packets, used for example to re-send them for newly connected clients
         PlayerInf lastPlayerInfPacket = PlayerInf();
         GameInf lastGameInfPacket = GameInf();
+        GameInf emptyGameInfPacket = GameInf();
         CostumeInf lastCostumeInfPacket = CostumeInf();
 
         Keyboard* mKeyboard = nullptr; // keyboard for setting server IP


### PR DESCRIPTION
Resend because: on server restarts the server will lose the stage information.

If only one client is connected to the server, the `GameInf` packet currently isn't resent, so the server doesn't know in which stage the client is (which I'd like to display on the website).

With more then one client connected it already works, because when another client joins the server, the client will send its `GameInf` packet.