### PR TITLE
separate build for emulators

### DIFF
--- a/.github/actions/attach/action.yml
+++ b/.github/actions/attach/action.yml
@@ -27,7 +27,7 @@ runs:
     shell : bash
     run: |
       cd  ./starlight_patch_100/
-      zip  -rmT9  ${{ inputs.filename }}.zip  ./*
+      zip  -rmT9  "${{ inputs.filename }}.zip"  ./*
   -
     name : Attach to release
     uses : actions/upload-release-asset@v1
@@ -36,5 +36,10 @@ runs:
     with:
       upload_url         : ${{ inputs.upload_url }}
       asset_path         : ./starlight_patch_100/${{ inputs.filename }}.zip
-      asset_name         : ${{ inputs.filename }}.zip
+      asset_name         : "${{ inputs.filename }}.zip"
       asset_content_type : application/zip
+  -
+    name  : Cleanup artifacts
+    shell : bash
+    run: |
+      rm -rf ./starlight_patch_100/

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -10,6 +10,10 @@ inputs:
     description : 'filename prefix'
     required    : false
     default     : ''
+  emu:
+    description : 'what system the build is for, Switch or Emulators'
+    required    : false
+    default     : 'Switch'
 
 
 outputs:
@@ -28,7 +32,7 @@ runs:
     run: |
       VERS=${{ inputs.tag }}
       echo "::set-output name=version::${VERS:1}"
-      echo "::set-output name=filename::${{ inputs.prefix }}SMO_Online${{ (inputs.tag != '' && format('_{0}', inputs.tag)) || '' }}"
+      echo "::set-output name=filename::${{ inputs.prefix }}SMO_Online${{ (inputs.tag != '' && format('_{0}', inputs.tag)) || '' }}_for_${{ inputs.emu }}"
   -
     name : Set up Docker Buildx
     uses : docker/setup-buildx-action@v2
@@ -49,9 +53,10 @@ runs:
     name  : Build mod
     shell : bash
     run: |
-      docker  run  --rm     \
-        -u `id -u`:`id -g`  \
-        -v "/$PWD/":/app/   \
+      docker  run  --rm             \
+        -u `id -u`:`id -g`          \
+        -v "/$PWD/":/app/           \
+        -e ISEMU=${{ (inputs.emu == 'Emulators' && '1') || '0' }}  \
         ${{ (steps.env.outputs.version != '' && format('-e BUILDVER={0}', steps.env.outputs.version)) || '' }}  \
         smoo-build-env      \
       ;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,9 @@ on:
 jobs:
 
   build:
+    strategy:
+      matrix:
+        emu : [ Switch, Emulators ]
     runs-on: ubuntu-latest
     steps:
     -
@@ -28,3 +31,5 @@ jobs:
     -
       name : Build artifacts
       uses : ./.github/actions/build
+      with:
+        emu : ${{ matrix.emu }}

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -19,9 +19,13 @@ concurrency:
 jobs:
 
   build:
+    strategy:
+      matrix:
+        emu : [ Switch, Emulators ]
     runs-on: ubuntu-latest
     outputs:
-      filename: ${{ steps.build.outputs.filename }}
+      filename1: ${{ steps.set-output.outputs.filename-Switch }}
+      filename2: ${{ steps.set-output.outputs.filename-Emulators }}
     steps:
     -
       name : Checkout
@@ -38,6 +42,13 @@ jobs:
       uses : ./.github/actions/build
       with:
         prefix : ${{ steps.env.outputs.prefix }}
+        emu    : ${{ matrix.emu }}
+    -
+      name  : Set output
+      id    : set-output
+      shell : bash
+      run   : |
+        echo "::set-output name=filename-${{ matrix.emu }}::${{ steps.build.outputs.filename }}"
 
   attach:
     needs: build
@@ -54,10 +65,17 @@ jobs:
         url=`curl -sS --fail ${{ github.api_url }}/repos/${{ github.repository }}/releases/tags/${{ env.TAG }} | jq .upload_url -r`
         echo "::set-output name=upload_url::$url"
     -
-      name : Attach build artifacts to release
+      name : Attach build artifacts to release (Switch)
       uses : ./.github/actions/attach
       with:
-        filename     : ${{ needs.build.outputs.filename }}
+        filename     : ${{ needs.build.outputs.filename1 }}
+        upload_url   : ${{ steps.release.outputs.upload_url }}
+        GITHUB_TOKEN : ${{ secrets.GITHUB_TOKEN }}
+    -
+      name : Attach build artifacts to release (Emulators)
+      uses : ./.github/actions/attach
+      with:
+        filename     : ${{ needs.build.outputs.filename2 }}
         upload_url   : ${{ steps.release.outputs.upload_url }}
         GITHUB_TOKEN : ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,13 @@ on:
 jobs:
 
   build:
+    strategy:
+      matrix:
+        emu : [ Switch, Emulators ]
     runs-on: ubuntu-latest
     outputs:
-      filename: ${{ steps.build.outputs.filename }}
+      filename1: ${{ steps.set-output.outputs.filename-Switch }}
+      filename2: ${{ steps.set-output.outputs.filename-Emulators }}
     steps:
     -
       name : Checkout
@@ -25,6 +29,13 @@ jobs:
       uses : ./.github/actions/build
       with:
         tag : ${{ github.ref_name }}
+        emu : ${{ matrix.emu }}
+    -
+      name  : Set output
+      id    : set-output
+      shell : bash
+      run   : |
+        echo "::set-output name=filename-${{ matrix.emu }}::${{ steps.build.outputs.filename }}"
 
   release:
     needs: build
@@ -41,9 +52,16 @@ jobs:
         tag          : ${{ github.ref_name }}
         GITHUB_TOKEN : ${{ secrets.GITHUB_TOKEN }}
     -
-      name : Attach build artifacts to release
+      name : Attach build artifacts to release (Switch)
       uses : ./.github/actions/attach
       with:
-        filename     : ${{ needs.build.outputs.filename }}
+        filename     : ${{ needs.build.outputs.filename1 }}
+        upload_url   : ${{ steps.release.outputs.upload_url }}
+        GITHUB_TOKEN : ${{ secrets.GITHUB_TOKEN }}
+    -
+      name : Attach build artifacts to release (Emulators)
+      uses : ./.github/actions/attach
+      with:
+        filename     : ${{ needs.build.outputs.filename2 }}
         upload_url   : ${{ steps.release.outputs.upload_url }}
         GITHUB_TOKEN : ${{ secrets.GITHUB_TOKEN }}

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
+ISEMU=${1:-0}
+
 export DOCKER_BUILDKIT=1
 docker  build  .  -t smoo-client-build
 docker  run  --rm       \
   -u $(id -u):$(id -g)  \
   -v "/$PWD/":/app/     \
+  -e ISEMU=${ISEMU}     \
   smoo-client-build     \
 ;
 docker  rmi  smoo-client-build


### PR DESCRIPTION
Build with `ISEMU=0` and `ISEMU=1` in parallel.
Upload both build artifacts to the releases as separate files.

Examples:
- Triggered Build: https://github.com/Istador/SuperMarioOdysseyOnline/actions/runs/2990119431
- Triggered Dev Release: https://github.com/Istador/SuperMarioOdysseyOnline/actions/runs/2990115862
- Latest dev releases: https://github.com/Istador/SuperMarioOdysseyOnline/releases/tag/latest-dev
  - `20220905_003101_SMO_Online_for_Emulators.zip`
  - `20220905_003101_SMO_Online_for_Switch.zip`
- Triggered Release: https://github.com/Istador/SuperMarioOdysseyOnline/actions/runs/2990150037
- Release: https://github.com/Istador/SuperMarioOdysseyOnline/releases/tag/v1.2.4-rcl
  - `SMO_Online_v1.2.4-rcl_for_Emulators.zip`
  - `SMO_Online_v1.2.4-rcl_for_Switch.zip`