### PR TITLE
don't send empty GameInf and CostumeInf packets and resend them on reconnect

### DIFF
--- a/include/packets/GameInf.h
+++ b/include/packets/GameInf.h
@@ -6,7 +6,7 @@
 struct PACKED GameInf : Packet {
     GameInf() : Packet() {this->mType = PacketType::GAMEINF; mPacketSize = sizeof(GameInf) - sizeof(Packet);};
     bool1 is2D = false;
-    u8 scenarioNo = -1;
+    u8 scenarioNo = 255;
     char stageName[0x40] = {};
 
     bool operator==(const GameInf &rhs) const {

--- a/include/server/Client.hpp
+++ b/include/server/Client.hpp
@@ -103,6 +103,7 @@ class Client {
         static void sendShineCollectPacket(int shineId);
         static void sendTagInfPacket();
         static void sendCaptureInfPacket(const PlayerActorHakoniwa *player);
+        void resendInitPackets();
 
         int getCollectedShinesCount() { return curCollectedShines.size(); }
         int getShineID(int index) { if (index < curCollectedShines.size()) { return curCollectedShines[index]; } return -1; }
@@ -226,6 +227,7 @@ class Client {
         // Backups for our last player/game packets, used for example to re-send them for newly connected clients
         PlayerInf lastPlayerInfPacket = PlayerInf();
         GameInf lastGameInfPacket = GameInf();
+        GameInf emptyGameInfPacket = GameInf();
         CostumeInf lastCostumeInfPacket = CostumeInf();
 
         Keyboard* mKeyboard = nullptr; // keyboard for setting server IP

--- a/include/server/SocketClient.hpp
+++ b/include/server/SocketClient.hpp
@@ -20,9 +20,11 @@
 
 #include "packets/Packet.h"
 
+class Client;
+
 class SocketClient : public SocketBase {
     public:
-        SocketClient(const char *name, sead::Heap *heap);
+        SocketClient(const char* name, sead::Heap* heap, Client* client);
         nn::Result init(const char* ip, u16 port) override;
         bool tryReconnect();
         bool closeSocket() override;
@@ -54,6 +56,7 @@ class SocketClient : public SocketBase {
 
     private:
         sead::Heap* mHeap = nullptr;
+        Client* client = nullptr;
         
         al::AsyncFunctorThread* mRecvThread = nullptr;
         al::AsyncFunctorThread* mSendThread = nullptr;


### PR DESCRIPTION
Resend because: on server restarts the server will lose the stage and costume information.

If only one client is connected to the server, the packets currently aren't resent, so the server doesn't know in which stage the client is and what costume it wears (which I'd like to display on the website).

With more then one client connected it already works, because when another client joins the server, the client will send both packets.

This is a recreation of PR #34 based on the latest `dev` branch version