### PR TITLE
Improve automatic builds

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -31,8 +31,8 @@ runs:
     shell : bash
     run: |
       VERS=${{ inputs.tag }}
-      echo "::set-output name=version::${VERS:1}"
-      echo "::set-output name=filename::${{ inputs.prefix }}SMO_Online${{ (inputs.tag != '' && format('_{0}', inputs.tag)) || '' }}_for_${{ inputs.emu }}"
+      echo "version=${VERS:1}" >>$GITHUB_OUTPUT
+      echo "filename=${{ inputs.prefix }}SMO_Online${{ (inputs.tag != '' && format('_{0}', inputs.tag)) || '' }}_for_${{ inputs.emu }}" >>$GITHUB_OUTPUT
   -
     name : Set up Docker Buildx
     uses : docker/setup-buildx-action@v2

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -11,7 +11,7 @@ inputs:
     required    : false
     default     : ''
   emu:
-    description : 'what system the build is for, Switch or Emulators'
+    description : 'what system the build is for: Switch, Ryujinx or yuzu'
     required    : false
     default     : 'Switch'
 
@@ -56,11 +56,22 @@ runs:
       docker  run  --rm             \
         -u `id -u`:`id -g`          \
         -v "/$PWD/":/app/           \
-        -e ISEMU=${{ (inputs.emu == 'Emulators' && '1') || '0' }}  \
+        -e ISEMU=${{ (inputs.emu != 'Switch' && '1') || '0' }}  \
         ${{ (steps.env.outputs.version != '' && format('-e BUILDVER={0}', steps.env.outputs.version)) || '' }}  \
         smoo-build-env      \
       ;
       cp  -r  ./romfs/  ./starlight_patch_100/atmosphere/contents/0100000000010000/.
+  -
+    name  : Yuzu
+    shell : bash
+    if    : ${{ inputs.emu == 'yuzu' }}
+    run: |
+      cd  ./starlight_patch_100/
+      mkdir  ./SMOO/
+      mv  ./atmosphere/contents/0100000000010000/exefs  ./SMOO/exefs
+      mv  ./atmosphere/contents/0100000000010000/romfs  ./SMOO/romfs
+      mv  ./atmosphere/exefs_patches/StarlightBase/3CA12DFAAF9C82DA064D1698DF79CDA1.ips  ./SMOO/romfs/
+      rm  -rf  ./atmosphere/
   -
     name : Upload artifacts
     uses : actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     strategy:
       matrix:
-        emu : [ Switch, Emulators ]
+        emu : [ Switch, Ryujinx, yuzu ]
     runs-on: ubuntu-latest
     steps:
     -

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -21,11 +21,12 @@ jobs:
   build:
     strategy:
       matrix:
-        emu : [ Switch, Emulators ]
+        emu : [ Switch, Ryujinx, yuzu ]
     runs-on: ubuntu-latest
     outputs:
       filename1: ${{ steps.set-output.outputs.filename-Switch }}
-      filename2: ${{ steps.set-output.outputs.filename-Emulators }}
+      filename2: ${{ steps.set-output.outputs.filename-Ryujinx }}
+      filename3: ${{ steps.set-output.outputs.filename-yuzu }}
     steps:
     -
       name : Checkout
@@ -72,10 +73,17 @@ jobs:
         upload_url   : ${{ steps.release.outputs.upload_url }}
         GITHUB_TOKEN : ${{ secrets.GITHUB_TOKEN }}
     -
-      name : Attach build artifacts to release (Emulators)
+      name : Attach build artifacts to release (Ryujinx)
       uses : ./.github/actions/attach
       with:
         filename     : ${{ needs.build.outputs.filename2 }}
+        upload_url   : ${{ steps.release.outputs.upload_url }}
+        GITHUB_TOKEN : ${{ secrets.GITHUB_TOKEN }}
+    -
+      name : Attach build artifacts to release (yuzu)
+      uses : ./.github/actions/attach
+      with:
+        filename     : ${{ needs.build.outputs.filename3 }}
         upload_url   : ${{ steps.release.outputs.upload_url }}
         GITHUB_TOKEN : ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -35,7 +35,7 @@ jobs:
       id    : env
       shell : bash
       run: |
-        echo "::set-output name=prefix::$(date +'%Y%m%d_%H%M%S_' --utc)"
+        echo "prefix=$(date +'%Y%m%d_%H%M%S_' --utc)" >>$GITHUB_OUTPUT
     -
       name : Build artifacts
       id   : build
@@ -48,7 +48,7 @@ jobs:
       id    : set-output
       shell : bash
       run   : |
-        echo "::set-output name=filename-${{ matrix.emu }}::${{ steps.build.outputs.filename }}"
+        echo "filename-${{ matrix.emu }}=${{ steps.build.outputs.filename }}" >>$GITHUB_OUTPUT
 
   attach:
     needs: build
@@ -63,7 +63,7 @@ jobs:
       shell : bash
       run: |
         url=`curl -sS --fail ${{ github.api_url }}/repos/${{ github.repository }}/releases/tags/${{ env.TAG }} | jq .upload_url -r`
-        echo "::set-output name=upload_url::$url"
+        echo "upload_url=$url" >>$GITHUB_OUTPUT
     -
       name : Attach build artifacts to release (Switch)
       uses : ./.github/actions/attach

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,12 @@ jobs:
   build:
     strategy:
       matrix:
-        emu : [ Switch, Emulators ]
+        emu : [ Switch, Ryujinx, yuzu ]
     runs-on: ubuntu-latest
     outputs:
       filename1: ${{ steps.set-output.outputs.filename-Switch }}
-      filename2: ${{ steps.set-output.outputs.filename-Emulators }}
+      filename2: ${{ steps.set-output.outputs.filename-Ryujinx }}
+      filename3: ${{ steps.set-output.outputs.filename-yuzu }}
     steps:
     -
       name : Checkout
@@ -59,9 +60,16 @@ jobs:
         upload_url   : ${{ steps.release.outputs.upload_url }}
         GITHUB_TOKEN : ${{ secrets.GITHUB_TOKEN }}
     -
-      name : Attach build artifacts to release (Emulators)
+      name : Attach build artifacts to release (Ryujinx)
       uses : ./.github/actions/attach
       with:
         filename     : ${{ needs.build.outputs.filename2 }}
+        upload_url   : ${{ steps.release.outputs.upload_url }}
+        GITHUB_TOKEN : ${{ secrets.GITHUB_TOKEN }}
+    -
+      name : Attach build artifacts to release (yuzu)
+      uses : ./.github/actions/attach
+      with:
+        filename     : ${{ needs.build.outputs.filename3 }}
         upload_url   : ${{ steps.release.outputs.upload_url }}
         GITHUB_TOKEN : ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,13 @@
-FROM  ubuntu:20.04  as  builder
+FROM  devkitpro/devkita64:latest  as  builder
 
 # install dependencies
 RUN   apt-get  update       \
   &&  apt-get  install  -y  \
-    curl                    \
-    apt-transport-https     \
     python3                 \
     python3-pip             \
-  &&  pip  install  keystone-engine  \
-;
-
-# install devkitpro
-RUN   ln  -s  /proc/self/mounts  /etc/mtab  \
-  &&  mkdir  /devkitpro/  \
-  &&  echo "deb [signed-by=/devkitpro/pub.gpg] https://apt.devkitpro.org stable main" >/etc/apt/sources.list.d/devkitpro.list  \
-  &&  curl --fail  -o /devkitpro/pub.gpg  https://apt.devkitpro.org/devkitpro-pub.gpg  \
-  &&  apt-get update  \
-  &&  DEBIAN_FRONTEND=noninteractive  apt-get  install  -y  devkitpro-pacman  \
-  &&  dkp-pacman  --noconfirm  -S switch-dev  \
+  &&  pip3  install  keystone-engine  \
 ;
 
 WORKDIR  /app/
 
-ENV  DEVKITPRO  /opt/devkitpro
 ENTRYPOINT  make


### PR DESCRIPTION
- less failing builds
- remove deprecation warning
  - it will still throw deprecation warnings for releases on the [actions/upload-release-asset](https://github.com/actions/upload-release-asset) step, which needs to be updated or replaced.
- separate build for yuzu