### PR TITLE
Allow udp communication for movement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,14 +45,14 @@ emu:
 	mv $(shell basename $(CURDIR))$(SMOVER).nso starlight_patch_$(SMOVER)/yuzu/subsdk1
 # builds and sends project to FTP server hosted on provided IP
 send: all
-	python3.8 scripts/sendPatch.py $(IP) $(PROJNAME) 
+	python3 scripts/sendPatch.py $(IP) $(PROJNAME)
 
 log: all
-	python3.8 scripts/tcpServer.py $(SERVERIP)
+	python3 scripts/tcpServer.py $(SERVERIP)
 
 sendlog: all
-	python3.8 scripts/sendPatch.py $(IP) $(PROJNAME) $(USER) $(PASS)
-	python3.8 scripts/tcpServer.py $(SERVERIP)
+	python3 scripts/sendPatch.py $(IP) $(PROJNAME) $(USER) $(PASS)
+	python3 scripts/tcpServer.py $(SERVERIP)
 
 clean:
 	$(MAKE) clean -f MakefileNSO

--- a/include/game/System/GameSystemInfo.h
+++ b/include/game/System/GameSystemInfo.h
@@ -37,7 +37,7 @@ namespace al {
             al::GameDrawInfo *mDrawInfo;                   // 0x38 from Application::sInstance + 0x30
             ProjectNfpDirector *mProjNfpDirector;          // 0x48 
             al::HtmlViewer *mHtmlViewer;                   // 0x50 
-            ApplicationMessageReceiver *mMessageReciever;  // 0x58 
+            ApplicationMessageReceiver *mMessageReceiver;  // 0x58
             al::WaveVibrationHolder *mWaveVibrationHolder; // 0x60 
             void *gap2;
     };

--- a/include/nn/socket.h
+++ b/include/nn/socket.h
@@ -42,8 +42,9 @@ s32 SendTo(s32 socket, const void* data, ulong dataLen, s32 flags, const struct 
 s32 Recv(s32 socket, void* out, ulong outLen, s32 flags);
 s32 RecvFrom(s32 socket, void* out, ulong outLen, s32 flags, struct sockaddr* from, u32* fromLen);
 
-s32 GetSockName(s32 socket, struct sockaddr* name, u32 dataLen);
+s32 GetSockName(s32 socket, struct sockaddr* name, u32* dataLen);
 u16 InetHtons(u16 val);
+u16 InetNtohs(u16 val);
 s32 InetAton(const char* addressStr, in_addr* addressOut);
 
 struct hostent* GetHostByName(const char* name);

--- a/include/nn/socket.h
+++ b/include/nn/socket.h
@@ -2,6 +2,12 @@
 
 #include "../types.h"
 
+struct pollfd
+{
+	s32   fd;
+	s16   events;
+	s16   revents;
+};
 
 struct in_addr
 {

--- a/include/nn/socket.h
+++ b/include/nn/socket.h
@@ -38,13 +38,18 @@ s32 Connect(s32 socket,	const sockaddr* address, u32 addressLen);
 Result Close(s32 socket);
 
 s32 Send(s32 socket, const void* data, ulong dataLen, s32 flags);
+s32 SendTo(s32 socket, const void* data, ulong dataLen, s32 flags, const struct sockaddr* to, u32 toLen);
 s32 Recv(s32 socket, void* out, ulong outLen, s32 flags);
+s32 RecvFrom(s32 socket, void* out, ulong outLen, s32 flags, struct sockaddr* from, u32* fromLen);
 
+s32 GetSockName(s32 socket, struct sockaddr* name, u32 dataLen);
 u16 InetHtons(u16 val);
 s32 InetAton(const char* addressStr, in_addr* addressOut);
 
 struct hostent* GetHostByName(const char* name);
 
 u32 GetLastErrno();
+s32 Bind(s32 fd, sockaddr* addr, u32 addrlen);
+s32 Poll(struct pollfd* fd, u64 addr, s32 timeout);
 
 } }

--- a/include/packets/HolePunchPacket.h
+++ b/include/packets/HolePunchPacket.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "Packet.h"
+
+struct PACKED HolePunch : Packet {
+    HolePunch() : Packet() {this->mType = PacketType::HOLEPUNCH; mPacketSize = sizeof(HolePunch) - sizeof(Packet);};
+};

--- a/include/packets/Packet.h
+++ b/include/packets/Packet.h
@@ -10,7 +10,7 @@
 #define PACKBUFSIZE      0x30
 #define COSTUMEBUFSIZE   0x20
 
-#define MAXPACKSIZE      0x100
+#define MAXPACKSIZE      0x50
 
 enum PacketType : short {
     UNKNOWN,

--- a/include/packets/Packet.h
+++ b/include/packets/Packet.h
@@ -26,6 +26,7 @@ enum PacketType : short {
     CAPTUREINF,
     CHANGESTAGE,
     CMD,
+    UDPINIT,
     End // end of enum for bounds checking
 };
 
@@ -44,6 +45,7 @@ USED static const char *packetNames[] = {
     "Capture Info",
     "Change Stage",
     "Server Command"
+    "Udp Initialization"
 };
 
 enum SenderType {
@@ -84,3 +86,4 @@ struct PACKED Packet {
 #include "packets/HackCapInf.h"
 #include "packets/ChangeStagePacket.h"
 #include "packets/InitPacket.h"
+#include "packets/UdpPacket.h"

--- a/include/packets/Packet.h
+++ b/include/packets/Packet.h
@@ -27,6 +27,7 @@ enum PacketType : short {
     CHANGESTAGE,
     CMD,
     UDPINIT,
+    HOLEPUNCH,
     End // end of enum for bounds checking
 };
 
@@ -44,8 +45,9 @@ USED static const char *packetNames[] = {
     "Moon Collection",
     "Capture Info",
     "Change Stage",
-    "Server Command"
-    "Udp Initialization"
+    "Server Command",
+    "Udp Initialization",
+    "Hole punch",
 };
 
 enum SenderType {
@@ -87,3 +89,4 @@ struct PACKED Packet {
 #include "packets/ChangeStagePacket.h"
 #include "packets/InitPacket.h"
 #include "packets/UdpPacket.h"
+#include "packets/HolePunchPacket.h"

--- a/include/packets/Packet.h
+++ b/include/packets/Packet.h
@@ -10,7 +10,7 @@
 #define PACKBUFSIZE      0x30
 #define COSTUMEBUFSIZE   0x20
 
-#define MAXPACKSIZE      0x50
+#define MAXPACKSIZE      0x100
 
 enum PacketType : short {
     UNKNOWN,

--- a/include/packets/UdpPacket.h
+++ b/include/packets/UdpPacket.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "Packet.h"
+
+struct PACKED UdpInit : Packet {
+    UdpInit() : Packet() {this->mType = PacketType::UDPINIT; mPacketSize = sizeof(UdpInit) - sizeof(Packet);};
+    u16 port = 0;
+};

--- a/include/server/Client.hpp
+++ b/include/server/Client.hpp
@@ -219,7 +219,7 @@ class Client {
 
         // --- Server Syncing Members --- 
         
-        // array of shine IDs for checking if multiple shines have been collected in quick sucession, all moons within the players stage that match the ID will be deleted
+        // array of shine IDs for checking if multiple shines have been collected in quick succession, all moons within the players stage that match the ID will be deleted
         sead::SafeArray<int, 128> curCollectedShines;
         int collectedShineCount = 0;
 

--- a/include/server/Client.hpp
+++ b/include/server/Client.hpp
@@ -197,6 +197,8 @@ class Client {
         void updateTagInfo(TagInf *packet);
         void updateCaptureInfo(CaptureInf* packet);
         void sendToStage(ChangeStagePacket* packet);
+        void sendUdpHolePunch();
+        void sendUdpInit();
         void disconnectPlayer(PlayerDC *packet);
 
         PuppetInfo* findPuppetInfo(const nn::account::Uid& id, bool isFindAvailable);

--- a/include/server/SocketClient.hpp
+++ b/include/server/SocketClient.hpp
@@ -74,6 +74,7 @@ class SocketClient : public SocketBase {
         int maxBufSize = 100;
         bool mIsFirstConnect = true;
         bool mPacketQueueOpen = true;
+        int pollTime = 0;
 
 
         bool mHasRecvUdp;

--- a/include/server/SocketClient.hpp
+++ b/include/server/SocketClient.hpp
@@ -64,6 +64,7 @@ class SocketClient : public SocketBase {
         
         sead::MessageQueue mRecvQueue;
         sead::MessageQueue mSendQueue;
+        char* recvBuf = nullptr;
 
         int maxBufSize = 100;
         bool mIsFirstConnect = true;

--- a/include/server/SocketClient.hpp
+++ b/include/server/SocketClient.hpp
@@ -70,7 +70,7 @@ class SocketClient : public SocketBase {
         sead::MessageQueue mSendQueue;
         char* recvBuf = nullptr;
 
-        int mMaxBufSize = 100;
+        int maxBufSize = 100;
         bool mIsFirstConnect = true;
         bool mPacketQueueOpen = true;
 

--- a/include/server/SocketClient.hpp
+++ b/include/server/SocketClient.hpp
@@ -67,6 +67,7 @@ class SocketClient : public SocketBase {
         char* recvBuf = nullptr;
 
         int mMaxBufSize = 100;
+        bool mIsFirstConnect = true;
 
         bool mHasRecvUdp;
         s32 mUdpSocket;

--- a/include/server/SocketClient.hpp
+++ b/include/server/SocketClient.hpp
@@ -29,6 +29,8 @@ class SocketClient : public SocketBase {
         void printPacket(Packet* packet);
         bool isConnected() {return socket_log_state == SOCKET_LOG_CONNECTED; }
 		u16 getUdpPort();
+		s32 setPeerUdpPort(u16 port);
+
 
         sead::PtrArray<Packet> mPacketQueue;
 

--- a/include/server/SocketClient.hpp
+++ b/include/server/SocketClient.hpp
@@ -46,6 +46,7 @@ class SocketClient : public SocketBase {
 
 		u16 getLocalUdpPort();
 		s32 setPeerUdpPort(u16 port);
+        const char* getUdpStateChar();
 
         u32 getSendCount() { return mSendQueue.getCount(); }
         u32 getSendMaxCount() { return mSendQueue.getMaxCount(); }

--- a/include/server/SocketClient.hpp
+++ b/include/server/SocketClient.hpp
@@ -28,13 +28,15 @@ class SocketClient : public SocketBase {
         bool RECV();
         void printPacket(Packet* packet);
         bool isConnected() {return socket_log_state == SOCKET_LOG_CONNECTED; }
+		u16 getUdpPort();
 
         sead::PtrArray<Packet> mPacketQueue;
 
     private:
         int maxBufSize = 100;
 
-	s32 udp_socket;
+		s32 udp_socket;
+		sockaddr udp_addr;
 
 
         /**

--- a/include/server/SocketClient.hpp
+++ b/include/server/SocketClient.hpp
@@ -44,8 +44,8 @@ class SocketClient : public SocketBase {
         void printPacket(Packet* packet);
         bool isConnected() { return socket_log_state == SOCKET_LOG_CONNECTED; }
 
-		u16 getLocalUdpPort();
-		s32 setPeerUdpPort(u16 port);
+        u16 getLocalUdpPort();
+        s32 setPeerUdpPort(u16 port);
         const char* getUdpStateChar();
 
         u32 getSendCount() { return mSendQueue.getCount(); }
@@ -66,12 +66,11 @@ class SocketClient : public SocketBase {
         sead::MessageQueue mSendQueue;
         char* recvBuf = nullptr;
 
-        int maxBufSize = 100;
-        bool mIsFirstConnect = true;
+        int mMaxBufSize = 100;
 
-	    bool has_recv_udp;
-		s32 udp_socket;
-		sockaddr udp_addr;
+        bool mHasRecvUdp;
+        s32 mUdpSocket;
+        sockaddr mUdpAddress;
 
 
         /**

--- a/include/server/SocketClient.hpp
+++ b/include/server/SocketClient.hpp
@@ -34,6 +34,9 @@ class SocketClient : public SocketBase {
     private:
         int maxBufSize = 100;
 
+	s32 udp_socket;
+
+
         /**
          * @param str a string containing an IPv4 address or a hostname that can be resolved via DNS
          * @param out IPv4 address

--- a/include/server/SocketClient.hpp
+++ b/include/server/SocketClient.hpp
@@ -44,7 +44,7 @@ class SocketClient : public SocketBase {
         void printPacket(Packet* packet);
         bool isConnected() { return socket_log_state == SOCKET_LOG_CONNECTED; }
 
-		u16 getUdpPort();
+		u16 getLocalUdpPort();
 		s32 setPeerUdpPort(u16 port);
 
         u32 getSendCount() { return mSendQueue.getCount(); }

--- a/include/server/SocketClient.hpp
+++ b/include/server/SocketClient.hpp
@@ -80,6 +80,8 @@ class SocketClient : public SocketBase {
         s32 mUdpSocket;
         sockaddr mUdpAddress;
 
+        bool recvTcp();
+        bool recvUdp();
 
         /**
          * @param str a string containing an IPv4 address or a hostname that can be resolved via DNS

--- a/include/server/SocketClient.hpp
+++ b/include/server/SocketClient.hpp
@@ -37,6 +37,7 @@ class SocketClient : public SocketBase {
     private:
         int maxBufSize = 100;
 
+	    bool has_recv_udp;
 		s32 udp_socket;
 		sockaddr udp_addr;
 

--- a/include/server/SocketClient.hpp
+++ b/include/server/SocketClient.hpp
@@ -29,12 +29,13 @@ class SocketClient : public SocketBase {
 
         bool startThreads();
         void endThreads();
+        void waitForThreads();
 
         bool send(Packet* packet);
         bool recv();
 
         bool queuePacket(Packet *packet);
-        void trySendQueue();
+        bool trySendQueue();
 
         void sendFunc();
         void recvFunc();

--- a/scripts/sendPatch.py
+++ b/scripts/sendPatch.py
@@ -35,36 +35,37 @@ if '.' not in consoleIP:
     print(sys.argv[0], "ERROR: Please specify with `IP=[Your console's IP]`")
     sys.exit(-1)
 
-isNeedOtherSwitch = True
-
-altSwitchIP = sys.argv[2]
-if '.' not in altSwitchIP:
-    isNeedOtherSwitch = False
+isNeedOtherSwitch = False
 
 consolePort = 5000
 
-if len(sys.argv) < 4:
+if len(sys.argv) < 3:
     projName = 'StarlightBase'
 else:
-    projName = sys.argv[3]
+    projName = sys.argv[2]
+
+if len(sys.argv) < 5:
+    user = 'crafty'
+    passwd = 'boss'
+else:
+    user = sys.argv[3]
+    passwd = sys.argv[4]
 
 curDir = os.curdir
 
 ftp = FTP()
 
-otherftp = FTP()
-
 print(f'Connecting to {consoleIP}... ', end='')
 ftp.connect(consoleIP, consolePort)
 print('logging into server...', end='')
-ftp.login('crafty','boss')
+ftp.login(user,passwd)
 print('Connected!')
 
 if isNeedOtherSwitch:
     print(f'Connecting to {altSwitchIP}... ', end='')
     otherftp.connect(altSwitchIP, consolePort)
     print('logging into server...', end='')
-    otherftp.login('crafty','boss')
+    otherftp.login(user,passwd)
     print('Connected!')
 
 patchDirectories = []

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -118,6 +118,7 @@ void drawMainHook(HakoniwaSequence *curSequence, sead::Viewport *viewport, sead:
     }
 
     gTextWriter->printf("Client Socket Connection Status: %s\n", Client::instance()->mSocket->getStateChar());
+	gTextWriter->printf("Udp socket status: %s\n", Client::instance()->mSocket->getUdpStateChar());
     //gTextWriter->printf("nn::socket::GetLastErrno: 0x%x\n", Client::instance()->mSocket->socket_errno);
     gTextWriter->printf("Connected Players: %d/%d\n", Client::getConnectCount() + 1, Client::getMaxPlayerCount());
     

--- a/source/puppets/PuppetHolder.cpp
+++ b/source/puppets/PuppetHolder.cpp
@@ -17,7 +17,7 @@ PuppetHolder::PuppetHolder(int size) {
  * @brief resizes puppet ptr array by creating a new ptr array and storing previous ptrs in it, before freeing the previous array
  * 
  * @param size the size of the new ptr array
- * @return returns true if resizing was sucessful
+ * @return returns true if resizing was successful
  */
 bool PuppetHolder::resizeHolder(int size) {
 

--- a/source/server/Client.cpp
+++ b/source/server/Client.cpp
@@ -90,13 +90,13 @@ void Client::init(al::LayoutInitInfo const &initInfo, GameDataHolderAccessor hol
 /**
  * @brief starts client read thread
  * 
- * @return true if read thread was sucessfully started
+ * @return true if read thread was succesfully started
  * @return false if read thread was unable to start, or thread was already started.
  */
 bool Client::startThread() {
     if(mReadThread->isDone() ) {
         mReadThread->start();
-        Logger::log("Read Thread Sucessfully Started.\n");
+        Logger::log("Read Thread Successfully Started.\n");
         return true;
     }else {
         Logger::log("Read Thread has already started! Or other unknown reason.\n");
@@ -132,7 +132,7 @@ void Client::restartConnection() {
     sInstance->mHeap->free(playerDC);
 
     if (sInstance->mSocket->closeSocket()) {
-        Logger::log("Sucessfully Closed Socket.\n");
+        Logger::log("Succesfully Closed Socket.\n");
     }
 
 	Logger::log("Waiting for send/recv threads to finish.\n");
@@ -145,7 +145,7 @@ void Client::restartConnection() {
 
     if(sInstance->mSocket->getLogState() == SOCKET_LOG_CONNECTED) {
 
-        Logger::log("Reconnect Sucessful!\n");
+        Logger::log("Reconnect Succesful!\n");
 
     } else {
         Logger::log("Reconnect Unsuccessful.\n");
@@ -187,7 +187,7 @@ bool Client::startConnection() {
 
     if (mIsConnectionActive) {
 
-        Logger::log("Sucessful Connection. Waiting to recieve init packet.\n");
+        Logger::log("Succesful Connection. Waiting to receive init packet.\n");
 
         bool waitingForInitPacket = true;
         // wait for client init packet
@@ -211,7 +211,7 @@ bool Client::startConnection() {
                 mHeap->free(curPacket);
 
             } else {
-                Logger::log("Recieve failed! Stopping Connection.\n");
+                Logger::log("Receive failed! Stopping Connection.\n");
                 mIsConnectionActive = false;
                 waitingForInitPacket = false;
             }
@@ -336,7 +336,7 @@ void Client::readFunc() {
 
     while(mIsConnectionActive) {
 
-        Packet *curPacket = mSocket->tryGetPacket();  // will block until a packet has been recieved, or socket disconnected
+        Packet *curPacket = mSocket->tryGetPacket();  // will block until a packet has been received, or socket disconnected
 
         if (curPacket) {
 

--- a/source/server/Client.cpp
+++ b/source/server/Client.cpp
@@ -383,6 +383,19 @@ void Client::readFunc() {
                 maxPuppets = initPacket->maxPlayers - 1;
                 break;
             }
+			case PacketType::UDPINIT: {
+				UdpInit* initPacket = (UdpInit*)curPacket;
+				Logger::log("Received udp init packet from server");
+				
+				sInstance->mSocket->setPeerUdpPort(initPacket->port);
+				sendUdpHolePunch();
+				sendUdpInit();
+				
+				break;
+			}
+			case PacketType::HOLEPUNCH: 
+				sendUdpHolePunch();
+				break;
             default:
                 Logger::log("Discarding Unknown Packet Type.\n");
                 break;
@@ -939,7 +952,45 @@ void Client::sendToStage(ChangeStagePacket* packet) {
         GameDataFunction::tryChangeNextStage(accessor, &info);
     }
 }
+/**
+ * @brief 
+ * Send a udp holepunch packet to the server
+ */
+void Client::sendUdpHolePunch() {
 
+    if (!sInstance) {
+        Logger::log("Static Instance is Null!\n");
+        return;
+    }
+
+    sead::ScopedCurrentHeapSetter setter(sInstance->mHeap);
+    
+    HolePunch *packet = new HolePunch();
+	
+    packet->mUserID = sInstance->mUserID;
+
+    sInstance->mSocket->queuePacket(packet);
+}
+/**
+ * @brief 
+ * Send a udp init packet to server
+ */
+void Client::sendUdpInit() {
+
+    if (!sInstance) {
+        Logger::log("Static Instance is Null!\n");
+        return;
+    }
+
+    sead::ScopedCurrentHeapSetter setter(sInstance->mHeap);
+    
+    UdpInit *packet = new UdpInit();
+	
+    packet->mUserID = sInstance->mUserID;
+	packet->port = sInstance->mSocket->getLocalUdpPort();
+	
+    sInstance->mSocket->queuePacket(packet);
+}
 /**
  * @brief 
  * 

--- a/source/server/Client.cpp
+++ b/source/server/Client.cpp
@@ -373,10 +373,6 @@ void Client::readFunc() {
 
     mSocket->SEND(&initPacket);  // send initial packet
 
-	UdpInit udp_init = UdpInit();
-	udp_init.port = mSocket->getUdpPort();
-	mSocket->SEND(&udp_init)
-
     nn::os::SleepThread(nn::TimeSpan::FromNanoSeconds(500000000)); // sleep for 0.5 seconds to let connection layout fully show (probably should find a better way to do this)
 
     mConnectionWait->tryEnd();
@@ -478,6 +474,19 @@ void Client::readFunc() {
                     InitPacket* initPacket = (InitPacket*)curPacket;
                     Logger::log("Server Max Player Size: %d\n", initPacket->maxPlayers);
                     maxPuppets = initPacket->maxPlayers - 1;
+                    break;
+                }
+                case PacketType::UDPINIT: {
+                    UdpInit* udpInit = (UdpInit*)curPacket;
+                    Logger::log("Setting udp port %u\n", udpInit->port);
+                    this->mSocket->setPeerUdpPort(udpInit->port);
+
+                    HolePunch punch = HolePunch();
+                    this->mSocket->SEND(&punch);
+
+                    UdpInit udp_init = UdpInit();
+                    udp_init.port = mSocket->getUdpPort();
+                    mSocket->SEND(&udp_init);
                     break;
                 }
                 default:

--- a/source/server/Client.cpp
+++ b/source/server/Client.cpp
@@ -385,7 +385,7 @@ void Client::readFunc() {
             }
 			case PacketType::UDPINIT: {
 				UdpInit* initPacket = (UdpInit*)curPacket;
-				Logger::log("Received udp init packet from server");
+				Logger::log("Received udp init packet from server\n");
 				
 				sInstance->mSocket->setPeerUdpPort(initPacket->port);
 				sendUdpHolePunch();

--- a/source/server/Client.cpp
+++ b/source/server/Client.cpp
@@ -243,6 +243,8 @@ bool Client::startConnection() {
                 waitingForInitPacket = false;
             }
         }
+
+
     }
 
     return mIsConnectionActive;
@@ -370,7 +372,11 @@ void Client::readFunc() {
     }
 
     mSocket->SEND(&initPacket);  // send initial packet
-    
+
+	UdpInit udp_init = UdpInit();
+	udp_init.port = mSocket->getUdpPort();
+	mSocket->SEND(&udp_init)
+
     nn::os::SleepThread(nn::TimeSpan::FromNanoSeconds(500000000)); // sleep for 0.5 seconds to let connection layout fully show (probably should find a better way to do this)
 
     mConnectionWait->tryEnd();

--- a/source/server/SocketBase.cpp
+++ b/source/server/SocketBase.cpp
@@ -72,12 +72,13 @@ s32 SocketBase::getFd() {
 
 bool SocketBase::closeSocket() {
 
-    this->socket_log_state = SOCKET_LOG_DISCONNECTED; // probably not safe to assume socket will be closed
+	if (this->socket_log_state != SOCKET_LOG_DISCONNECTED) {
+		nn::Result result = nn::socket::Close(this->socket_log_socket);
+		if (result.isSuccess()) {
+			this->socket_log_state = SOCKET_LOG_DISCONNECTED;
+		}
+		return result.isSuccess();
+	}
 
-    nn::Result result = nn::socket::Close(this->socket_log_socket);
-
-    return result.isSuccess();
+	return true;
 }
-
-
-

--- a/source/server/SocketBase.cpp
+++ b/source/server/SocketBase.cpp
@@ -72,13 +72,13 @@ s32 SocketBase::getFd() {
 
 bool SocketBase::closeSocket() {
 
-	if (this->socket_log_state != SOCKET_LOG_DISCONNECTED) {
-		nn::Result result = nn::socket::Close(this->socket_log_socket);
-		if (result.isSuccess()) {
-			this->socket_log_state = SOCKET_LOG_DISCONNECTED;
-		}
-		return result.isSuccess();
-	}
+    if (this->socket_log_state != SOCKET_LOG_DISCONNECTED) {
+        nn::Result result = nn::socket::Close(this->socket_log_socket);
+        if (result.isSuccess()) {
+            this->socket_log_state = SOCKET_LOG_DISCONNECTED;
+        }
+        return result.isSuccess();
+    }
 
-	return true;
+    return true;
 }

--- a/source/server/SocketClient.cpp
+++ b/source/server/SocketClient.cpp
@@ -87,8 +87,9 @@ nn::Result SocketClient::init(const char* ip, u16 port) {
         return -1;
 	}
 
+	// TODO Find a way around the 41553 constant port
     udpAddress.address = hostAddress;
-    udpAddress.port = nn::socket::InetHtons(0);
+    udpAddress.port = nn::socket::InetHtons(41553);
     udpAddress.family = 2;
     this->udp_addr = udpAddress;
 	this->has_recv_udp = false;
@@ -156,7 +157,7 @@ s32 SocketClient::setPeerUdpPort(u16 port) {
 }
 
 const char* SocketClient::getUdpStateChar() {
-	if (this->udp_addr.port == 0) {
+	if (this->udp_addr.port == 41553) {
 		return "Waiting for handshake";
 	}
 	

--- a/source/server/SocketClient.cpp
+++ b/source/server/SocketClient.cpp
@@ -281,7 +281,7 @@ if (index == 1) {
                     int result = nn::socket::Recv(fd, packetBuf + valread,
                                                   fullSize - valread, this->sock_flags);
 
-                    this->socket_errno = nn::socket::GetLastErrno();revents
+                    this->socket_errno = nn::socket::GetLastErrno();
 
                     if (result > 0) {
                         valread += result;

--- a/source/server/SocketClient.cpp
+++ b/source/server/SocketClient.cpp
@@ -381,6 +381,7 @@ bool SocketClient::closeSocket() {
 
     Logger::log("Closing Socket.\n");
 
+	has_recv_udp = false;
     bool result = false;
 
     if (!(result = SocketBase::closeSocket())) {

--- a/source/server/SocketClient.cpp
+++ b/source/server/SocketClient.cpp
@@ -73,14 +73,15 @@ nn::Result SocketClient::init(const char* ip, u16 port) {
         this->socket_log_state = SOCKET_LOG_UNAVAILABLE;
         return -1;
 	}
+
     udpAddress.address = hostAddress;
     udpAddress.port = nn::socket::InetHtons(41553);
     udpAddress.family = 2;
     this->udp_addr = udpAddress;
 
-    udpAddress.address = hostAddress;
-    udpAddress.port = nn::socket::InetHtons(57734);
-    udpAddress.family = 2;
+    // udpAddress.address = hostAddress;
+    // udpAddress.port = nn::socket::InetHtons(57734);
+    // udpAddress.family = 2;
 
     if((result = nn::socket::Connect(this->udp_socket, &udpAddress, sizeof(udpAddress))).isFailure()) {
         Logger::log("Udp Socket Connection Failed!\n");

--- a/source/server/SocketClient.cpp
+++ b/source/server/SocketClient.cpp
@@ -243,7 +243,7 @@ bool SocketClient::recv() {
 
         // Verify type of packet
         if (!(header->mType > PacketType::UNKNOWN && header->mType < PacketType::End)) {
-            Logger::log("Failed to acquire valid packet type! Packet Type: %d Full Packet Size %d valread size: %d", header->mType, fullSize, result);
+            Logger::log("Failed to acquire valid packet type! Packet Type: %d Full Packet Size %d valread size: %d\n", header->mType, fullSize, result);
             return true;
         }
 
@@ -326,7 +326,7 @@ bool SocketClient::recv() {
                 }
 
                 if (!(header->mType > PacketType::UNKNOWN && header->mType < PacketType::End)) {
-                    Logger::log("Failed to acquire valid packet type! Packet Type: %d Full Packet Size %d valread size: %d", header->mType, fullSize, valread);
+                    Logger::log("Failed to acquire valid packet type! Packet Type: %d Full Packet Size %d valread size: %d\n", header->mType, fullSize, valread);
                     mHeap->free(packetBuf);
                     return true;
                 }

--- a/source/server/SocketClient.cpp
+++ b/source/server/SocketClient.cpp
@@ -250,18 +250,21 @@ bool SocketClient::recv() {
         this->mHasRecvUdp = true;
 
         char* packetBuf = (char*)mHeap->alloc(fullSize);
-        if (packetBuf){
-            memcpy(packetBuf, recvBuf, fullSize);
-
-
-            Packet *packet = reinterpret_cast<Packet*>(packetBuf);
-
-            if(!mRecvQueue.isFull()) {
-                mRecvQueue.push((s64)packet, sead::MessageQueue::BlockType::NonBlocking);
-            } else {
-                mHeap->free(packetBuf);
-            }
+        if (!packetBuf) {
+            return true
         }
+
+        memcpy(packetBuf, recvBuf, fullSize);
+
+
+        Packet *packet = reinterpret_cast<Packet*>(packetBuf);
+
+        if(!mRecvQueue.isFull()) {
+            mRecvQueue.push((s64)packet, sead::MessageQueue::BlockType::NonBlocking);
+        } else {
+            mHeap->free(packetBuf);
+        }
+
         return true;
     }
 

--- a/source/server/SocketClient.cpp
+++ b/source/server/SocketClient.cpp
@@ -15,6 +15,11 @@
 #include "types.h"
 
 SocketClient::SocketClient(const char* name, sead::Heap* heap) : mHeap(heap), SocketBase(name) {
+#if EMU
+    this->pollTime = 0;
+#else
+    this->pollTime = -1;
+#endif
 
     mRecvThread = new al::AsyncFunctorThread("SocketRecvThread", al::FunctorV0M<SocketClient*, SocketThreadFunc>(this, &SocketClient::recvFunc), 0, 0x1000, {0});
     mSendThread = new al::AsyncFunctorThread("SocketSendThread", al::FunctorV0M<SocketClient*, SocketThreadFunc>(this, &SocketClient::sendFunc), 0, 0x1000, {0});
@@ -219,7 +224,7 @@ bool SocketClient::recv() {
     pfds[1].revents = 0;
 
 
-    int result = nn::socket::Poll(pfds, fd_count, 0);
+    int result = nn::socket::Poll(pfds, fd_count, this->pollTime);
 
     if (result == 0) {
         return true;

--- a/source/server/SocketClient.cpp
+++ b/source/server/SocketClient.cpp
@@ -170,8 +170,14 @@ bool SocketClient::send(Packet *packet) {
     int valread = 0;
 
     int fd = -1;
-    if ((packet->mType != PLAYERINF && packet->mType != HACKCAPINF && packet->mType != HOLEPUNCH) || !this->mHasRecvUdp) {
-        Logger::log("Sending packet: %s\n", packetNames[packet->mType]);
+    if ((packet->mType != PLAYERINF && packet->mType != HACKCAPINF && packet->mType != HOLEPUNCH)
+        || (!this->mHasRecvUdp && packet->mType != HOLEPUNCH)
+        || this->mUdpAddress.port == 0) {
+
+        if (packet->mType != PLAYERINF && packet->mType != HACKCAPINF) {
+            Logger::log("Sending packet: %s\n", packetNames[packet->mType]);
+        }
+
         fd = this->socket_log_socket;
     } else {
 

--- a/source/server/SocketClient.cpp
+++ b/source/server/SocketClient.cpp
@@ -104,7 +104,7 @@ nn::Result SocketClient::init(const char* ip, u16 port) {
 
     Logger::log("Socket fd: %d\n", socket_log_socket);
 
-    startThreads();  // start recv and send threads after sucessful connection
+    startThreads();  // start recv and send threads after succesful connection
 
     // send init packet to server once we connect (an issue with the server prevents this from working properly, waiting for a fix to implement)
     
@@ -470,7 +470,7 @@ bool SocketClient::stringToIPAddress(const char* str, in_addr* out) {
 /**
  * @brief starts client read thread
  * 
- * @return true if read thread was sucessfully started
+ * @return true if read thread was successfully started
  * @return false if read thread was unable to start, or thread was already started.
  */
 bool SocketClient::startThreads() {
@@ -481,7 +481,7 @@ bool SocketClient::startThreads() {
     if(this->mRecvThread->isDone() && this->mSendThread->isDone()) {
         this->mRecvThread->start();
         this->mSendThread->start();
-        Logger::log("Socket threads sucessfully started.\n");
+        Logger::log("Socket threads succesfully started.\n");
         return true;
     }else {
         Logger::log("Socket threads failed to start.\n");

--- a/source/server/SocketClient.cpp
+++ b/source/server/SocketClient.cpp
@@ -253,8 +253,8 @@ bool SocketClient::recv() {
 
         Packet *packet = reinterpret_cast<Packet*>(packetBuf);
 
-        if(mPacketQueue.size() < maxBufSize - 1) {
-            mPacketQueue.pushBack(packet);
+        if(!mRecvQueue.isFull()) {
+            mRecvQueue.push((s64)packet, sead::MessageQueue::BlockType::NonBlocking);
 			this->has_recv_udp = true;
         } else {
             free(packetBuf);

--- a/source/server/SocketClient.cpp
+++ b/source/server/SocketClient.cpp
@@ -180,7 +180,7 @@ bool SocketClient::RECV() {
 	pfds[1].revents = 0;
 
 
-	if (nn::socket::Poll(pfds, fd_count, -1) <= 0) {
+	if (nn::socket::Poll(pfds, fd_count, 0) <= 0) {
 		return true;
 	}
 

--- a/source/server/SocketClient.cpp
+++ b/source/server/SocketClient.cpp
@@ -89,17 +89,10 @@ nn::Result SocketClient::init(const char* ip, u16 port) {
 
     // TODO Find a way around the 41553 constant port
     udpAddress.address = hostAddress;
-    udpAddress.port = nn::socket::InetHtons(41553);
+    udpAddress.port = 0;
     udpAddress.family = 2;
     this->udp_addr = udpAddress;
     this->has_recv_udp = false;
-
-    if((result = nn::socket::Connect(this->udp_socket, &udpAddress, sizeof(udpAddress))).isFailure()) {
-        Logger::log("Udp Socket Connection Failed!\n");
-        this->socket_errno = nn::socket::GetLastErrno();
-        this->socket_log_state = SOCKET_LOG_UNAVAILABLE;
-        return result;
-    }
 
     this->socket_log_state = SOCKET_LOG_CONNECTED;
 
@@ -157,7 +150,7 @@ s32 SocketClient::setPeerUdpPort(u16 port) {
 }
 
 const char* SocketClient::getUdpStateChar() {
-    if (this->udp_addr.port == 41553) {
+    if (this->udp_addr.port == 0) {
         return "Waiting for handshake";
     }
 
@@ -394,6 +387,7 @@ bool SocketClient::closeSocket() {
     Logger::log("Closing Socket.\n");
 
     has_recv_udp = false;
+	udp_addr.port = 0;
     bool result = false;
 
     if (!(result = SocketBase::closeSocket())) {

--- a/source/server/SocketClient.cpp
+++ b/source/server/SocketClient.cpp
@@ -81,7 +81,7 @@ nn::Result SocketClient::init(const char* ip, u16 port) {
         return result;
     }
 
-    if ((this->ket = nn::socket::Socket(2, 2, 17)) < 0) {
+    if ((this->mUdpSocket = nn::socket::Socket(2, 2, 17)) < 0) {
         Logger::log("Udp Socket failed to create");
         this->socket_errno = nn::socket::GetLastErrno();
         this->socket_log_state = SOCKET_LOG_UNAVAILABLE;
@@ -125,7 +125,7 @@ u16 SocketClient::getLocalUdpPort() {
     u32 size = sizeof(udpAddress);
 
     nn::Result result;
-    if((result = nn::socket::GetSockName(this->ket, &udpAddress, &size)).isFailure()) {
+    if((result = nn::socket::GetSockName(this->mUdpSocket, &udpAddress, &size)).isFailure()) {
         this->socket_errno = nn::socket::GetLastErrno();
         return 0;
     }
@@ -176,7 +176,7 @@ bool SocketClient::send(Packet *packet) {
         fd = this->socket_log_socket;
     } else {
 
-        fd = this->ket;
+        fd = this->mUdpSocket;
     }
 
 
@@ -207,7 +207,7 @@ bool SocketClient::recv() {
     pfds[0].fd = this->socket_log_socket;
     pfds[0].events = 1;
     pfds[0].revents = 0;
-    pfds[1].fd = this->ket;
+    pfds[1].fd = this->mUdpSocket;
     pfds[1].events = 1;
     pfds[1].revents = 0;
 
@@ -341,7 +341,7 @@ bool SocketClient::recv() {
                 }
             }
         } else {
-            Logger::log("Failed to acquire valid data! Packet Type: %d Full Packet Size %d valread size: %d", header->mType, fullSize, valread);
+            Logger::log("Failed to acquire valid data! Packet Type: %d Full Packet Size %d valread size: %d\n", header->mType, fullSize, valread);
         }
         
         return true;

--- a/source/server/SocketClient.cpp
+++ b/source/server/SocketClient.cpp
@@ -138,7 +138,7 @@ bool SocketClient::SEND(Packet *packet) {
     int valread = 0;
 
 	int fd = -1;
-    if (packet->mType != PLAYERINF && packet->mType != HACKCAPINF && packet->mType != HOLEPUNCH) {
+    if ((packet->mType != PLAYERINF && packet->mType != HACKCAPINF && packet->mType != HOLEPUNCH) || !this->has_recv_udp) {
 		Logger::log("Sending packet: %s\n", packetNames[packet->mType]);
 		fd = this->socket_log_socket;
 	} else {
@@ -196,7 +196,8 @@ bool SocketClient::RECV() {
 	if (fd == -1) {
 		return true;
 	}
-if (index == 1) {
+
+	if (index == 1) {
         int result = nn::socket::Recv(fd, headerBuf, sizeof(headerBuf), this->sock_flags);
         if (result < headerSize){
             return true;
@@ -224,6 +225,7 @@ if (index == 1) {
 
         if(mPacketQueue.size() < maxBufSize - 1) {
             mPacketQueue.pushBack(packet);
+			this->has_recv_udp = true;
         } else {
             free(packetBuf);
         }

--- a/source/server/SocketClient.cpp
+++ b/source/server/SocketClient.cpp
@@ -199,7 +199,7 @@ bool SocketClient::recv() {
     }
     
     int headerSize = sizeof(Packet);
-    char headerBuf[MAXPACKSIZE * 2] = {};
+    char headerBuf[MAXPACKSIZE + 1] = {0};
     int valread = 0;
 
     const int fd_count = 2;

--- a/source/server/SocketClient.cpp
+++ b/source/server/SocketClient.cpp
@@ -139,10 +139,9 @@ s32 SocketClient::setPeerUdpPort(u16 port) {
     this->mUdpAddress.port = net_port;
 
     nn::Result result;
-    if((result = nn::socket::Connect(this->ket, &this->mUdpAddress, sizeof(this->mUdpAddress))).isFailure()) {
-        Logger::log("Udp Socket Connection Failed!\n");
+    if((result = nn::socket::Connect(this->mUdpSocket, &this->mUdpAddress, sizeof(this->mUdpAddress))).isFailure()) {
+        Logger::log("Udp socket connection failed to connect to port %d!\n", port);
         this->socket_errno = nn::socket::GetLastErrno();
-        this->socket_log_state = SOCKET_LOG_UNAVAILABLE;
         return -1;
     }
 

--- a/source/server/SocketClient.cpp
+++ b/source/server/SocketClient.cpp
@@ -257,7 +257,7 @@ bool SocketClient::recv() {
 
         char* packetBuf = (char*)mHeap->alloc(fullSize);
         if (!packetBuf) {
-            return true
+            return true;
         }
 
         memcpy(packetBuf, recvBuf, fullSize);

--- a/source/server/SocketClient.cpp
+++ b/source/server/SocketClient.cpp
@@ -30,7 +30,7 @@ nn::Result SocketClient::init(const char* ip, u16 port) {
     
     in_addr  hostAddress   = { 0 };
     sockaddr serverAddress = { 0 };
-    sockaddr udpAddress = { 0 };
+    sockaddr udpAddress    = { 0 };
 
     Logger::log("SocketClient::init: %s:%d sock %s\n", ip, port, getStateChar());
 
@@ -87,7 +87,6 @@ nn::Result SocketClient::init(const char* ip, u16 port) {
         return -1;
     }
 
-    // TODO Find a way around the 41553 constant port
     udpAddress.address = hostAddress;
     udpAddress.port = 0;
     udpAddress.family = 2;

--- a/source/server/SocketClient.cpp
+++ b/source/server/SocketClient.cpp
@@ -235,7 +235,7 @@ bool SocketClient::recv() {
     }
 
     if (index == 1) {
-        int result = nn::socket::Recv(fd, recvBuf, sizeof(MAXPACKSIZE), this->sock_flags);
+        int result = nn::socket::Recv(fd, recvBuf, MAXPACKSIZE, this->sock_flags);
         if (result < headerSize){
             return true;
         }

--- a/source/server/SocketClient.cpp
+++ b/source/server/SocketClient.cpp
@@ -88,7 +88,7 @@ nn::Result SocketClient::init(const char* ip, u16 port) {
 	}
 
     udpAddress.address = hostAddress;
-    udpAddress.port = nn::socket::InetHtons(41553);
+    udpAddress.port = nn::socket::InetHtons(0);
     udpAddress.family = 2;
     this->udp_addr = udpAddress;
 	this->has_recv_udp = false;
@@ -155,6 +155,17 @@ s32 SocketClient::setPeerUdpPort(u16 port) {
 
 }
 
+const char* SocketClient::getUdpStateChar() {
+	if (this->udp_addr.port == 0) {
+		return "Waiting for handshake";
+	}
+	
+	if (!this->has_recv_udp) {
+		return "Waiting for holepunch";
+	}
+	
+	return "Utilizing UDP";
+}
 bool SocketClient::send(Packet *packet) {
 
     if (this->socket_log_state != SOCKET_LOG_CONNECTED)

--- a/source/server/logger.cpp
+++ b/source/server/logger.cpp
@@ -111,7 +111,7 @@ void Logger::log(const char* fmt, ...) {
 }
 
 bool Logger::pingSocket() {
-    return socket_log("ping") > 0; // if value is greater than zero, than the socket recieved our message, otherwise the connection was lost.
+    return socket_log("ping") > 0; // if value is greater than zero, than the socket received our message, otherwise the connection was lost.
 }
 
 void tryInitSocket() {


### PR DESCRIPTION
I did a lot in this PR, so please let know if there are things that should be changed. By itself, it should still work with all servers as expected as the client should always fall back to using strictly TCP. However, only the UDP rust server will allow use of the UDP feature currently. Also with the send queue bottleneck, the UDP improvements don't feel very noticeable. Here is a small summary of what I did.

If you have any questions, ping me on discord.

Network stuff:
- Adds several packet types to perform a UDP handshake.
- If UDP connection active, send all player and cap packets through UDP, everything else remains on TCP
- Add debug menu item to show UDP status
- Change recv to be polling
- Split recv to be a TCP and UDP variant
- Allows unknown packets to properly be consumed from socket (same as #37)
- Changed TCP recv to use if guards to prevent indention pyramid

Bug fixes:
- Fix a race condition involving every thread trying to close socket and failing
- Drain send/recv queues on reconnect
- Hopefully fix a race condition with both send/recv threads initializing each other

Tooling:
- Change Makefile to use python3 instead of python3.8
- Change tcp script to use USER and PASS like Makefile expected

Unimportant stuff:
- Fix success and receive spelling errors :P
- Maybe added some tabs on accident (please tell me if you find any)