### PR TITLE
fix: mark player as not a seeker when H&S is disabled

### DIFF
--- a/source/server/Client.cpp
+++ b/source/server/Client.cpp
@@ -622,7 +622,7 @@ void Client::sendTagInfPacket() {
 
     packet->mUserID = sInstance->mUserID;
 
-    packet->isIt = hsMode->isPlayerIt();
+    packet->isIt = hsMode->isPlayerIt() && hsMode->isModeActive();
 
     packet->minutes = curInfo->mHidingTime.mMinutes;
     packet->seconds = curInfo->mHidingTime.mSeconds;

--- a/source/server/hns/HideAndSeekMode.cpp
+++ b/source/server/hns/HideAndSeekMode.cpp
@@ -84,6 +84,8 @@ void HideAndSeekMode::begin() {
         playGuideLyt->end();
 
     GameModeBase::begin();
+
+    Client::sendTagInfPacket();
 }
 
 void HideAndSeekMode::end() {
@@ -109,6 +111,8 @@ void HideAndSeekMode::end() {
         playGuideLyt->appear();
 
     GameModeBase::end();
+
+    Client::sendTagInfPacket();
 }
 
 void HideAndSeekMode::update() {


### PR DESCRIPTION
If a player is a seeker and then disables H&S, they should no longer be considered as a seeker by other players. (Because staying as a seeker will kill hiders when touching them).

Current faulty behaviour:
```
Player 1: join game
Player 2: join game
Player 1: enable H&S
Player 2: enable H&S
Player 1: switch to S
Player 1: disable H&S
Player 1: run into player 2 => player 2 dies
```