### PR TITLE
fix: `TagInf` and `CaptureInf` synchronization issues

### DIFF
--- a/include/server/Client.hpp
+++ b/include/server/Client.hpp
@@ -230,6 +230,7 @@ class Client {
         GameInf emptyGameInfPacket = GameInf();
         CostumeInf lastCostumeInfPacket = CostumeInf();
         TagInf lastTagInfPacket = TagInf();
+        CaptureInf lastCaptureInfPacket = CaptureInf();
 
         Keyboard* mKeyboard = nullptr; // keyboard for setting server IP
 

--- a/include/server/Client.hpp
+++ b/include/server/Client.hpp
@@ -229,6 +229,7 @@ class Client {
         GameInf lastGameInfPacket = GameInf();
         GameInf emptyGameInfPacket = GameInf();
         CostumeInf lastCostumeInfPacket = CostumeInf();
+        TagInf lastTagInfPacket = TagInf();
 
         Keyboard* mKeyboard = nullptr; // keyboard for setting server IP
 

--- a/source/server/Client.cpp
+++ b/source/server/Client.cpp
@@ -361,6 +361,8 @@ void Client::readFunc() {
                     mSocket->send(&lastPlayerInfPacket);
                 if (lastCostumeInfPacket.mUserID == mUserID)
                     mSocket->send(&lastCostumeInfPacket);
+                if (lastTagInfPacket.mUserID == mUserID)
+                    mSocket->send(&lastTagInfPacket);
 
                 break;
             case PacketType::COSTUMEINF:
@@ -629,6 +631,8 @@ void Client::sendTagInfPacket() {
     packet->updateType = static_cast<TagUpdateType>(TagUpdateType::STATE | TagUpdateType::TIME);
 
     sInstance->mSocket->queuePacket(packet);
+
+    sInstance->lastTagInfPacket = *packet;
 }
 
 /**
@@ -695,6 +699,11 @@ void Client::resendInitPackets() {
     // GameInfPacket
     if (lastGameInfPacket != emptyGameInfPacket) {
         mSocket->queuePacket(&lastGameInfPacket);
+    }
+
+    // TagInfPacket
+    if (lastTagInfPacket.mUserID == mUserID) {
+        mSocket->queuePacket(&lastTagInfPacket);
     }
 }
 

--- a/source/server/Client.cpp
+++ b/source/server/Client.cpp
@@ -363,6 +363,8 @@ void Client::readFunc() {
                     mSocket->send(&lastCostumeInfPacket);
                 if (lastTagInfPacket.mUserID == mUserID)
                     mSocket->send(&lastTagInfPacket);
+                if (lastCaptureInfPacket.mUserID == mUserID)
+                    mSocket->send(&lastCaptureInfPacket);
 
                 break;
             case PacketType::COSTUMEINF:
@@ -677,12 +679,14 @@ void Client::sendCaptureInfPacket(const PlayerActorHakoniwa* player) {
         packet->mUserID = sInstance->mUserID;
         strcpy(packet->hackName, tryConvertName(player->mHackKeeper->getCurrentHackName()));
         sInstance->mSocket->queuePacket(packet);
+        sInstance->lastCaptureInfPacket = *packet;
         sInstance->isSentCaptureInf = true;
     } else if (!sInstance->isClientCaptured && sInstance->isSentCaptureInf) {
         CaptureInf *packet = new CaptureInf();
         packet->mUserID = sInstance->mUserID;
         strcpy(packet->hackName, "");
         sInstance->mSocket->queuePacket(packet);
+        sInstance->lastCaptureInfPacket = *packet;
         sInstance->isSentCaptureInf = false;
     }
 }
@@ -704,6 +708,11 @@ void Client::resendInitPackets() {
     // TagInfPacket
     if (lastTagInfPacket.mUserID == mUserID) {
         mSocket->queuePacket(&lastTagInfPacket);
+    }
+
+    // CaptureInfPacket
+    if (lastCaptureInfPacket.mUserID == mUserID) {
+        mSocket->queuePacket(&lastCaptureInfPacket);
     }
 }
 

--- a/source/server/SocketClient.cpp
+++ b/source/server/SocketClient.cpp
@@ -104,6 +104,21 @@ nn::Result SocketClient::init(const char* ip, u16 port) {
     // on a reconnect, resend some maybe missing packets
     if (initPacket.conType == ConnectionTypes::RECONNECT) {
       client->resendInitPackets();
+    } else {
+        // empty TagInf
+        TagInf tagInf;
+        tagInf.mUserID = initPacket.mUserID;
+        tagInf.isIt = false;
+        tagInf.minutes = 0;
+        tagInf.seconds = 0;
+        tagInf.updateType = static_cast<TagUpdateType>(TagUpdateType::STATE | TagUpdateType::TIME);
+        send(&tagInf);
+
+        // empty CaptureInf
+        CaptureInf capInf;
+        capInf.mUserID = initPacket.mUserID;
+        strcpy(capInf.hackName, "");
+        send(&capInf);
     }
 
     return result;


### PR DESCRIPTION
This PR:
- Send empty `TagInf` and `CaptureInf` packets directly after connecting to the server, to reset old data back that other players might stll have in their puppet from an earlier connection.
- Resends `TagInf` and `CaptureInf` packets after reconnecting to fix possibly lost packets.
- Resends `TagInf` and `CaptureInf` packets when new players connect, so that they get the current state.

---

Current faulty behaviour:

1. Not sending `TagInf` to new players:
```
Player 1: join game
Player 1: enable H&S
Player 1: switch to S
Player 2: join game
Player 2: enable H&S
Player 1: run into player 2 => player 2 does not die
```

2. Not sending `TagInf` after reconnect:
```
Player 1: join game
Player 2: join game
Player 1: enable H&S
Player 2: enable H&S
Player 1: disconnect
Player 1: switch to S
Player 1: reconnect
Player 1: run into player 2 => player 2 does not die
```

3. Not sending empty `TagInf` on connect:
```
Player 1: join game
Player 2: join game
Player 1: enable H&S
Player 2: enable H&S
Player 1: switch to S
Player 1: quit game
Player 1: join game
Player 1: run into player 2 => player 2 does die
```

4. Not sending `CaptureInf` to new players:
```
Player 1: join game
Player 1: capture something
Player 2: join game
Player 2: sees player 1 as Mario
```

5. Not sending `CaptureInf` after reconnect:
```
Player 1: join game
Player 2: join game
Player 1: capture something
Player 1: disconnect
Player 1: uncapture
Player 1: reconnect
Player 2: still sees player 1 as a capture
```

6. Not sending empty `CaptureInf` on connect:
```
Player 1: join game
Player 2: join game
Player 1: capture something
Player 1: quit game
Player 1: join game
Player 2: still sees player 1 as a capture
```