### PR TITLE
UI improvements

### DIFF
--- a/include/game/StageScene/StageSceneStateServerConfig.hpp
+++ b/include/game/StageScene/StageSceneStateServerConfig.hpp
@@ -29,7 +29,6 @@ class StageSceneStateServerConfig : public al::HostStateBase<al::Scene>, public 
         enum ServerConfigOption {
             GAMEMODECONFIG,
             GAMEMODESWITCH,
-            RECONNECT,
             SETIP,
             SETPORT
         };
@@ -42,11 +41,9 @@ class StageSceneStateServerConfig : public al::HostStateBase<al::Scene>, public 
         void exeMainMenu();
         void exeOpenKeyboardIP();
         void exeOpenKeyboardPort();
-        void exeRestartServer();
         void exeGamemodeConfig();
         void exeGamemodeSelect();
         void exeSaveData();
-        void exeConnectError();
 
         void endSubMenu();
 
@@ -63,7 +60,7 @@ class StageSceneStateServerConfig : public al::HostStateBase<al::Scene>, public 
         
         SimpleLayoutMenu* mCurrentMenu = nullptr;
         CommonVerticalList* mCurrentList = nullptr;
-        // Root Page, contains buttons for gamemode config, server reconnecting, and server ip address changing
+        // Root Page, contains buttons for gamemode config, and server ip address changing
         SimpleLayoutMenu* mMainOptions = nullptr;
         CommonVerticalList *mMainOptionsList = nullptr;
         // Sub-Page of Mode config, used to select a gamemode for the client to use
@@ -86,9 +83,7 @@ namespace {
     NERVE_HEADER(StageSceneStateServerConfig, MainMenu)
     NERVE_HEADER(StageSceneStateServerConfig, OpenKeyboardIP)
     NERVE_HEADER(StageSceneStateServerConfig, OpenKeyboardPort)
-    NERVE_HEADER(StageSceneStateServerConfig, RestartServer)
     NERVE_HEADER(StageSceneStateServerConfig, GamemodeConfig)
     NERVE_HEADER(StageSceneStateServerConfig, GamemodeSelect)
     NERVE_HEADER(StageSceneStateServerConfig, SaveData)
-    NERVE_HEADER(StageSceneStateServerConfig, ConnectError)
 }

--- a/include/server/Client.hpp
+++ b/include/server/Client.hpp
@@ -16,6 +16,7 @@
 #include "al/LiveActor/LiveActor.h"
 #include "al/layout/LayoutInitInfo.h"
 #include "al/layout/SimpleLayoutAppearWaitEnd.h"
+#include "al/layout/WindowConfirmWait.h"
 #include "al/util.hpp"
 #include "al/layout/LayoutActor.h"
 #include "al/gamepad/util.h"
@@ -173,6 +174,9 @@ class Client {
         static bool openKeyboardIP();
         static bool openKeyboardPort();
 
+        static void showUIMessage(const char16_t* msg);
+        static void hideUIMessage();
+
         void resetCollectedShines();
 
         void removeShine(int shineId);
@@ -232,7 +236,7 @@ class Client {
         bool mIsFirstConnect = true;
 
         // --- Game Layouts ---
-
+        al::WindowConfirmWait* mUIMessage;
         al::SimpleLayoutAppearWaitEnd *mConnectStatus;
 
         // --- Game Info ---

--- a/include/server/Client.hpp
+++ b/include/server/Client.hpp
@@ -16,7 +16,6 @@
 #include "al/LiveActor/LiveActor.h"
 #include "al/layout/LayoutInitInfo.h"
 #include "al/layout/SimpleLayoutAppearWaitEnd.h"
-#include "al/layout/WindowConfirmWait.h"
 #include "al/util.hpp"
 #include "al/layout/LayoutActor.h"
 #include "al/gamepad/util.h"
@@ -88,7 +87,6 @@ class Client {
 
         bool startThread();
         void readFunc();
-        static void restartConnection();
 
         static bool isSocketActive() { return sInstance ? sInstance->mSocket->isConnected() : false; };
         bool isPlayerConnected(int index) { return mPuppetInfoArr[index]->isConnected; }
@@ -175,12 +173,6 @@ class Client {
         static bool openKeyboardIP();
         static bool openKeyboardPort();
 
-        static void showConnect();
-
-        static void showConnectError(const char16_t* msg);
-
-        static void hideConnect();
-
         void resetCollectedShines();
 
         void removeShine(int shineId);
@@ -240,8 +232,6 @@ class Client {
         bool mIsFirstConnect = true;
 
         // --- Game Layouts ---
-
-        al::WindowConfirmWait* mConnectionWait;
 
         al::SimpleLayoutAppearWaitEnd *mConnectStatus;
 

--- a/include/server/hns/HideAndSeekConfigMenu.hpp
+++ b/include/server/hns/HideAndSeekConfigMenu.hpp
@@ -9,11 +9,13 @@ public:
     HideAndSeekConfigMenu();
     
     void initMenu(const al::LayoutInitInfo &initInfo) override;
-    const sead::WFixedSafeString<0x200> *getStringData() override;
+    const sead::WFixedSafeString<0x200>* getStringData() override;
     bool updateMenu(int selectIndex) override;
 
     const int getMenuSize() override { return mItemCount; }
 
 private:
-    static constexpr int mItemCount = 2;
+    static constexpr int mItemCount = 1;
+    sead::SafeArray<sead::WFixedSafeString<0x200>, mItemCount>* gravityOn = nullptr;
+    sead::SafeArray<sead::WFixedSafeString<0x200>, mItemCount>* gravityOff = nullptr;
 };

--- a/source/server/Client.cpp
+++ b/source/server/Client.cpp
@@ -72,9 +72,12 @@ Client::Client() {
 void Client::init(al::LayoutInitInfo const &initInfo, GameDataHolderAccessor holder) {
 
     mConnectStatus = new (mHeap) al::SimpleLayoutAppearWaitEnd("", "SaveMessage", initInfo, 0, false);
-
     al::setPaneString(mConnectStatus, "TxtSave", u"Connecting to Server.", 0);
     al::setPaneString(mConnectStatus, "TxtSaveSh", u"Connecting to Server.", 0);
+
+    mUIMessage = new (mHeap) al::WindowConfirmWait("ServerWaitConnect", "WindowConfirmWait", initInfo);
+    mUIMessage->setTxtMessage(u"a");
+    mUIMessage->setTxtMessageConfirm(u"b");
 
     mHolder = holder;
 
@@ -248,6 +251,33 @@ bool Client::openKeyboardPort() {
     sInstance->mSocket->setIsFirstConn(isFirstConnect);
 
     return isFirstConnect;
+}
+
+
+void Client::showUIMessage(const char16_t* msg) {
+    if (!sInstance) {
+        return;
+    }
+
+    sInstance->mUIMessage->setTxtMessageConfirm(msg);
+
+    al::hidePane(sInstance->mUIMessage, "Page01");  // hide A button prompt
+
+    if (!sInstance->mUIMessage->mIsAlive) {
+        sInstance->mUIMessage->appear();
+
+        sInstance->mUIMessage->playLoop();
+    }
+
+    al::startAction(sInstance->mUIMessage, "Confirm", "State");
+}
+
+void Client::hideUIMessage() {
+    if (!sInstance) {
+        return;
+    }
+
+    sInstance->mUIMessage->tryEnd();
 }
 
 /**

--- a/source/server/Client.cpp
+++ b/source/server/Client.cpp
@@ -71,12 +71,7 @@ Client::Client() {
  */
 void Client::init(al::LayoutInitInfo const &initInfo, GameDataHolderAccessor holder) {
 
-    mConnectionWait = new (mHeap) al::WindowConfirmWait("ServerWaitConnect", "WindowConfirmWait", initInfo);
-    
     mConnectStatus = new (mHeap) al::SimpleLayoutAppearWaitEnd("", "SaveMessage", initInfo, 0, false);
-
-    mConnectionWait->setTxtMessage(u"Connecting to Server.");
-    mConnectionWait->setTxtMessageConfirm(u"Failed to Connect!");
 
     al::setPaneString(mConnectStatus, "TxtSave", u"Connecting to Server.", 0);
     al::setPaneString(mConnectStatus, "TxtSaveSh", u"Connecting to Server.", 0);
@@ -102,44 +97,6 @@ bool Client::startThread() {
     }else {
         Logger::log("Read Thread has already started! Or other unknown reason.\n");
         return false;
-    }
-}
-
-/**
- * @brief restarts currently active connection to server
- * 
- */
-void Client::restartConnection() {
-
-    if (!sInstance) {
-        Logger::log("Static Instance is null!\n");
-        return;
-    }
-
-    sead::ScopedCurrentHeapSetter setter(sInstance->mHeap);
-
-    Logger::log("Sending Disconnect.\n");
-
-    PlayerDC *playerDC = new PlayerDC();
-
-    playerDC->mUserID = sInstance->mUserID;
-
-    sInstance->mSocket->queuePacket(playerDC);
-
-    if (sInstance->mSocket->closeSocket()) {
-        Logger::log("Sucessfully Closed Socket.\n");
-    }
-
-    sInstance->mConnectCount = 0;
-
-    sInstance->mIsConnectionActive = sInstance->mSocket->init(sInstance->mServerIP.cstr(), sInstance->mServerPort).isSuccess();
-
-    if(sInstance->mSocket->getLogState() == SOCKET_LOG_CONNECTED) {
-
-        Logger::log("Reconnect Sucessful!\n");
-
-    } else {
-        Logger::log("Reconnect Unsuccessful.\n");
     }
 }
 
@@ -1392,38 +1349,4 @@ Shine* Client::findStageShine(int shineID) {
         }
     }
     return nullptr;
-}
-
-void Client::showConnectError(const char16_t* msg) {
-    if (!sInstance)
-        return;
-
-    sInstance->mConnectionWait->setTxtMessageConfirm(msg);
-
-    al::hidePane(sInstance->mConnectionWait, "Page01");  // hide A button prompt
-
-    if (!sInstance->mConnectionWait->mIsAlive) {
-        sInstance->mConnectionWait->appear();
-
-        sInstance->mConnectionWait->playLoop();
-    }
-
-    al::startAction(sInstance->mConnectionWait, "Confirm", "State");
-}
-
-void Client::showConnect() {
-    if (!sInstance)
-        return;
-    
-    sInstance->mConnectionWait->appear();
-
-    sInstance->mConnectionWait->playLoop();
-    
-}
-
-void Client::hideConnect() {
-    if (!sInstance)
-        return;
-
-    sInstance->mConnectionWait->tryEnd();
 }

--- a/source/server/hns/HideAndSeekConfigMenu.cpp
+++ b/source/server/hns/HideAndSeekConfigMenu.cpp
@@ -5,20 +5,27 @@
 #include "server/hns/HideAndSeekMode.hpp"
 #include "server/Client.hpp"
 
-HideAndSeekConfigMenu::HideAndSeekConfigMenu() : GameModeConfigMenu() {}
+HideAndSeekConfigMenu::HideAndSeekConfigMenu() : GameModeConfigMenu() {
+    gravityOn = new sead::SafeArray<sead::WFixedSafeString<0x200>, mItemCount>();
+    gravityOn->mBuffer[0].copy(u"Toggle H&S Gravity (ON)");
+
+    gravityOff = new sead::SafeArray<sead::WFixedSafeString<0x200>, mItemCount>();
+    gravityOff->mBuffer[0].copy(u"Toggle H&S Gravity (OFF)");
+}
 
 void HideAndSeekConfigMenu::initMenu(const al::LayoutInitInfo &initInfo) {
     
 }
 
-const sead::WFixedSafeString<0x200> *HideAndSeekConfigMenu::getStringData() {
-    sead::SafeArray<sead::WFixedSafeString<0x200>, mItemCount>* gamemodeConfigOptions =
-        new sead::SafeArray<sead::WFixedSafeString<0x200>, mItemCount>();
-
-    gamemodeConfigOptions->mBuffer[0].copy(u"Toggle H&S Gravity On");
-    gamemodeConfigOptions->mBuffer[1].copy(u"Toggle H&S Gravity Off");
-
-    return gamemodeConfigOptions->mBuffer;
+const sead::WFixedSafeString<0x200>* HideAndSeekConfigMenu::getStringData() {
+    HideAndSeekInfo *curMode = GameModeManager::instance()->getInfo<HideAndSeekInfo>();
+    return (
+        GameModeManager::instance()->isMode(GameMode::HIDEANDSEEK)
+        && curMode != nullptr
+        && curMode->mIsUseGravity
+        ? gravityOn->mBuffer
+        : gravityOff->mBuffer
+    );
 }
 
 bool HideAndSeekConfigMenu::updateMenu(int selectIndex) {
@@ -35,13 +42,7 @@ bool HideAndSeekConfigMenu::updateMenu(int selectIndex) {
     switch (selectIndex) {
         case 0: {
             if (GameModeManager::instance()->isMode(GameMode::HIDEANDSEEK)) {
-                curMode->mIsUseGravity = true;
-            }
-            return true;
-        }
-        case 1: {
-            if (GameModeManager::instance()->isMode(GameMode::HIDEANDSEEK)) {
-                curMode->mIsUseGravity = false;
+                curMode->mIsUseGravity = !curMode->mIsUseGravity;
             }
             return true;
         }

--- a/source/states/StageSceneStateServerConfig.cpp
+++ b/source/states/StageSceneStateServerConfig.cpp
@@ -100,11 +100,6 @@ StageSceneStateServerConfig::StageSceneStateServerConfig(const char *name, al::S
         entry.mList = new CommonVerticalList(entry.mLayout, initInfo, true);
 
         al::setPaneString(entry.mLayout, "TxtOption", u"Gamemode Configuration", 0);
-
-        entry.mList->initDataNoResetSelected(entry.mMenu->getMenuSize());
-
-
-        entry.mList->addStringData(entry.mMenu->getStringData(), "TxtContent");
     }
 
 
@@ -231,8 +226,13 @@ void StageSceneStateServerConfig::exeOpenKeyboardPort() {
 void StageSceneStateServerConfig::exeGamemodeConfig() {
     if (al::isFirstStep(this)) {
         mGamemodeConfigMenu = &mGamemodeConfigMenus[GameModeManager::instance()->getGameMode()];
+
+        mGamemodeConfigMenu->mList->initDataNoResetSelected(mGamemodeConfigMenu->mMenu->getMenuSize());
+        mGamemodeConfigMenu->mList->addStringData(mGamemodeConfigMenu->mMenu->getStringData(), "TxtContent");
+
         mCurrentList = mGamemodeConfigMenu->mList;
         mCurrentMenu = mGamemodeConfigMenu->mLayout;
+
         subMenuStart();
     }
 

--- a/source/states/StageSceneStateServerConfig.cpp
+++ b/source/states/StageSceneStateServerConfig.cpp
@@ -109,6 +109,15 @@ StageSceneStateServerConfig::StageSceneStateServerConfig(const char *name, al::S
 
 void StageSceneStateServerConfig::init() {
     initNerve(&nrvStageSceneStateServerConfigMainMenu, 0);
+
+    #ifdef EMU
+    char ryujinx[0x10] = { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    nn::account::Uid user;
+    nn::account::GetLastOpenedUser(&user);
+    if (memcmp(user.data, ryujinx, 0x10) == 0) {
+        Client::showUIMessage(u"Error: Ryujinx default profile detected.\nYou have to create a new user profile!");
+    }
+    #endif
 }
 
 void StageSceneStateServerConfig::appear(void) {

--- a/source/states/StageSceneStateServerConfig.cpp
+++ b/source/states/StageSceneStateServerConfig.cpp
@@ -41,14 +41,13 @@ StageSceneStateServerConfig::StageSceneStateServerConfig(const char *name, al::S
 
     mMainOptionsList->unkInt1 = 1;
 
-    mMainOptionsList->initDataNoResetSelected(5);
+    mMainOptionsList->initDataNoResetSelected(4);
 
-    sead::SafeArray<sead::WFixedSafeString<0x200>, 5>* mainMenuOptions =
-        new sead::SafeArray<sead::WFixedSafeString<0x200>, 5>();
+    sead::SafeArray<sead::WFixedSafeString<0x200>, 4>* mainMenuOptions =
+        new sead::SafeArray<sead::WFixedSafeString<0x200>, 4>();
 
     mainMenuOptions->mBuffer[ServerConfigOption::GAMEMODECONFIG].copy(u"Gamemode Config");
     mainMenuOptions->mBuffer[ServerConfigOption::GAMEMODESWITCH].copy(u"Change Gamemode");
-    mainMenuOptions->mBuffer[ServerConfigOption::RECONNECT].copy(u"Reconnect to Server");
     mainMenuOptions->mBuffer[ServerConfigOption::SETIP].copy(u"Change Server IP");
     mainMenuOptions->mBuffer[ServerConfigOption::SETPORT].copy(u"Change Server Port");
 
@@ -176,10 +175,6 @@ void StageSceneStateServerConfig::exeMainMenu() {
             al::setNerve(this, &nrvStageSceneStateServerConfigGamemodeSelect);
             break;
         }
-        case ServerConfigOption::RECONNECT: {
-            al::setNerve(this, &nrvStageSceneStateServerConfigRestartServer);
-            break;
-        }
         case ServerConfigOption::SETIP: {
             al::setNerve(this, &nrvStageSceneStateServerConfigOpenKeyboardIP);
             break;
@@ -233,27 +228,6 @@ void StageSceneStateServerConfig::exeOpenKeyboardPort() {
     }
 }
 
-void StageSceneStateServerConfig::exeRestartServer() {
-    if (al::isFirstStep(this)) {
-        mCurrentList->deactivate();
-
-        Client::showConnect();
-
-        Client::restartConnection();
-    }
-
-    if (Client::isSocketActive()) {
-
-        Client::hideConnect();
-
-        al::startHitReaction(mCurrentMenu, "リセット", 0);
-        
-        al::setNerve(this, &nrvStageSceneStateServerConfigMainMenu);
-    } else {
-        al::setNerve(this, &nrvStageSceneStateServerConfigConnectError);
-    }
-}
-
 void StageSceneStateServerConfig::exeGamemodeConfig() {
     if (al::isFirstStep(this)) {
         mGamemodeConfigMenu = &mGamemodeConfigMenus[GameModeManager::instance()->getGameMode()];
@@ -287,18 +261,6 @@ void StageSceneStateServerConfig::exeGamemodeSelect() {
         Logger::log("Setting Server Mode to: %d\n", mCurrentList->mCurSelected);
         GameModeManager::instance()->setMode(static_cast<GameMode>(mCurrentList->mCurSelected));
         endSubMenu();
-    }
-}
-
-void StageSceneStateServerConfig::exeConnectError() {
-    if (al::isFirstStep(this)) {
-        Client::showConnectError(u"Failed to Reconnect!");
-    }
-
-    if (al::isGreaterEqualStep(this, 60)) { // close after 1 second
-        Client::hideConnect();
-        al::startHitReaction(mCurrentMenu, "リセット", 0);
-        al::setNerve(this, &nrvStageSceneStateServerConfigMainMenu);
     }
 }
 
@@ -373,9 +335,7 @@ namespace {
 NERVE_IMPL(StageSceneStateServerConfig, MainMenu)
 NERVE_IMPL(StageSceneStateServerConfig, OpenKeyboardIP)
 NERVE_IMPL(StageSceneStateServerConfig, OpenKeyboardPort)
-NERVE_IMPL(StageSceneStateServerConfig, RestartServer)
 NERVE_IMPL(StageSceneStateServerConfig, GamemodeConfig)
 NERVE_IMPL(StageSceneStateServerConfig, GamemodeSelect)
 NERVE_IMPL(StageSceneStateServerConfig, SaveData)
-NERVE_IMPL(StageSceneStateServerConfig, ConnectError)
 }


### PR DESCRIPTION
1. Remove the reconnect button.
2. Convert the two `Toggle H&S Gravity` buttons into one button that actually toggles. (Note: it only works in the pause menu and not in the main menu - as it was before - because the H&S gamemode is not active in the main menu yet.)
3. Show an error message for Ryujinx users that haven't created a new user profile.