### PR TITLE
Add cooldown to automatic proximity sardine tin

### DIFF
--- a/include/server/gamemode/GameModeTimer.hpp
+++ b/include/server/gamemode/GameModeTimer.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <format>
-#include <string>
+#include "sead/prim/seadSafeString.h"
 
 struct GameTime {
     float mMilliseconds = 0;
@@ -9,11 +8,11 @@ struct GameTime {
     int   mMinutes      = 0;
     int   mHours        = 0;
 
-    const std::string to_string() {
+    const sead::SafeString to_string() {
         if (mHours > 0) {
-            return std::format("{:01}:{:02}:{:02}", mHours, mMinutes, mSeconds);
+            return sead::FormatFixedSafeString<0x20>("%01d:%02d:%02d", mHours, mMinutes, mSeconds);
         }
-        return std::format("{:02}:{:02}", mMinutes, mSeconds);
+        return sead::FormatFixedSafeString<0x20>("%02d:%02d", mMinutes, mSeconds);
     }
 };
 

--- a/include/server/sardines/SardineMode.hpp
+++ b/include/server/sardines/SardineMode.hpp
@@ -54,5 +54,8 @@ class SardineMode : public GameModeBase {
         float pullDistanceMinSq = 1000000.f;
         float pullPowerRate     = 75.f;
 
+        int mSardineToggleCooldown = 0;
+        const int mSardineToggleCooldownLength = 600;
+
         void updateTagState(bool isIt);
 };

--- a/source/server/hns/HideAndSeekIcon.cpp
+++ b/source/server/hns/HideAndSeekIcon.cpp
@@ -63,7 +63,7 @@ void HideAndSeekIcon::exeWait() {
         al::startAction(this, "Wait", 0);
     }
 
-    al::setPaneStringFormat(this, "TxtCounter", mInfo->mHidingTime.to_string().c_str());
+    al::setPaneStringFormat(this, "TxtCounter", mInfo->mHidingTime.to_string().cstr());
 
     auto playerList = getPlayerList();
     if (!playerList.isEmpty()) {

--- a/source/server/sardines/SardineIcon.cpp
+++ b/source/server/sardines/SardineIcon.cpp
@@ -63,7 +63,7 @@ void SardineIcon::exeWait() {
         al::startAction(this, "Wait", 0);
     }
 
-    al::setPaneStringFormat(this, "TxtCounter", mInfo->mHidingTime.to_string().c_str());
+    al::setPaneStringFormat(this, "TxtCounter", mInfo->mHidingTime.to_string().cstr());
 
     auto playerList = getPlayerList();
     if (!playerList.isEmpty()) {

--- a/source/server/sardines/SardineMode.cpp
+++ b/source/server/sardines/SardineMode.cpp
@@ -155,6 +155,9 @@ void SardineMode::update() {
     float closestDistanceSq = 0.f;
 
     bool isPackEmpty = true;
+    
+    if (mSardineToggleCooldown > 0)
+        mSardineToggleCooldown--;
 
     if (mIsFirstFrame) {
         if (mInfo->mIsUseGravityCam && mTicket) {
@@ -191,10 +194,12 @@ void SardineMode::update() {
              if (  isPlayerAlone()                                                          // we're a single sardine
                 && other->is2D == ((PlayerActorHakoniwa*)playerBase)->mDimKeeper->is2DModel // we are in the same dimension
                 && !PlayerFunction::isPlayerDeadStatus(playerBase)                          // we're not dead
+                && mSardineToggleCooldown == 0                                              // cooldown isn't active
             ) {
                 // in range?
                 float distanceSq = vecDistanceSq(playerPos, other->playerPos);
                 if (distanceSq < 90000.0f) { // non-squared: 300.0
+                    mSardineToggleCooldown = mSardineToggleCooldownLength;
                     updateTagState(true);
                     break;
                 }


### PR DESCRIPTION
Primary change:

- Previously being near a tinned player in the sardines would instantly put you in tin, even when trying to leave by pressing up on the d-pad. This PR adds a ten second cooldown after manually leaving the tin to avoid nearby players getting stuck in the tin state.

Extra changes:

- Remove random use of std library in `GameModeTimer.hpp`, replaced with `sead::SafeString`